### PR TITLE
Psana2

### DIFF
--- a/examples/lclstreamer-quynh.yaml
+++ b/examples/lclstreamer-quynh.yaml
@@ -1,5 +1,7 @@
 lclstreamer:
-    source_identifier: exp=xpply5120:run=318
+    source_identifier:
+        exp: xpply5120
+        run: 318
     batch_size: 100
     event_source: Psana1EventSource
     processing_pipeline: NoOpProcessingPipeline

--- a/examples/psana2.yaml
+++ b/examples/psana2.yaml
@@ -1,9 +1,9 @@
 lclstreamer:
     source_identifier:
-        exp: xpptut15
-        run: 430
+       exp: tmox1016823
+       run: 45
     batch_size: 1
-    event_source: Psana1EventSource
+    event_source: Psana2EventSource
     processing_pipeline: NoOpProcessingPipeline
     data_serializer: Hdf5Serializer
     skip_incomplete_events: True
@@ -13,24 +13,20 @@ lclstreamer:
 
 data_sources:
     timestamp:
-        type: Psana1Timestamp
+        type: Psana2Timestamp
 
-    detector_data:
-        type: Psana1AreaDetector
-        psana_name: Jungfrau1M
-        calibration: true
+#   detector_data:
+#       type: Psana2SpectralDetector
+#       psana_name: Z_piranha
+#       calibration: false
 
     random:
         type: GenericRandomNumpyArray
         array_shape: 4,4,4
         array_dtype: float32
 
-    photon_wavelength:
-        type: Psana1DetectorInterface
-        psana_name: "SIOC:SYS0:ML00:AO192"
-
 event_source:
-    Psana1EventSource: {}
+    Psana2EventSource: {}
 
 processing_pipeline:
     NoOpProcessingPipeline: {}
@@ -41,15 +37,13 @@ data_serializer:
         compression: zfp
         fields:
             timestamp: /data/timestamp
-            detector_data: /data/data
             random: /data/random
-            photon_wavelength: /data/wavelength
+            #detector_data: /data/data
+            #photon_wavelength: /data/wavelength
 
 data_handlers:
     BinaryFileWritingDataHandler:
-        file_prefix: ""
-        file_suffix: h5
-        write_directory: /sdf/home/v/valmar/Projects/lclstreamer/workspace/output
+        write_directory: /sdf/home/r/rogersdd/lclstreamer-output
 
     BinaryDataStreamingDataHandler:
         urls:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lclstreamer"
-requires-python = ">= 3.11"
+requires-python = ">= 3.9"
 version = "0.1.0"
 dependencies = ["typer>=0.15.2,<0.16", "numpy", "stream @ git+https://github.com/frobnitzem/stream.py", "pydantic>=2.10.6,<3", "pyyaml>=6.0.2,<7", "hdf5plugin>=5.1.0,<6", "pyzmq", "pynng>=0.8.1,<0.9", "mkdocs-material>=9.6.11,<10", "mkdocstrings-python>=1.16.10,<2", "rich>=14.0.0,<15"]
 

--- a/src/lclstreamer/backend/event_source.py
+++ b/src/lclstreamer/backend/event_source.py
@@ -4,6 +4,7 @@ from ..models.parameters import LclstreamerParameters, Parameters
 from ..protocols.backend import EventSourceProtocol
 from ..utils.logging_utils import log
 from .psana1.event_sources import Psana1EventSource  # noqa: F401
+from .psana2.event_sources import Psana2EventSource  # noqa: F401
 
 
 def initialize_event_source(

--- a/src/lclstreamer/backend/generic/data_sources.py
+++ b/src/lclstreamer/backend/generic/data_sources.py
@@ -18,6 +18,7 @@ class GenericRandomNumpyArray(DataSourceProtocol):
         self,
         name: str,
         parameters: DataSourceParameters,
+        run: Any,
     ):
         """
         Initializes a Generic Random Numpy Array data source.

--- a/src/lclstreamer/backend/generic/data_sources.py
+++ b/src/lclstreamer/backend/generic/data_sources.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any
+from typing import Any, Union, Optional
 
 import numpy
 from numpy.typing import NDArray
@@ -28,7 +28,7 @@ class GenericRandomNumpyArray(DataSourceProtocol):
 
             parameters: The configuration parameters
         """
-        extra_parameters: dict[str, Any] | None = parameters.__pydantic_extra__
+        extra_parameters: Optional[dict[str, Any]] = parameters.__pydantic_extra__
         if extra_parameters is None:
             log.error(f"Entries needed by the {name} data source are not defined")
             sys.exit(1)
@@ -56,7 +56,7 @@ class GenericRandomNumpyArray(DataSourceProtocol):
             )
             sys.exit(1)
 
-    def get_data(self, event: Any) -> NDArray[numpy.float_ | numpy.int_]:
+    def get_data(self, event: Any) -> Union[NDArray[numpy.float_],NDArray[numpy.int_]]:
         """
         Retrieves an array of int of float random numbers
 

--- a/src/lclstreamer/backend/psana1/data_sources.py
+++ b/src/lclstreamer/backend/psana1/data_sources.py
@@ -3,7 +3,11 @@ from typing import Any, Callable
 
 import numpy
 from numpy.typing import NDArray
-from psana import Detector, EventId  # type: ignore
+try:
+    from psana import Detector, EventId  # type: ignore
+except ImportError:
+    Detector = None  # type: ignore
+    EventId = None  # type: ignore
 
 from ...models.parameters import DataSourceParameters
 from ...protocols.backend import DataSourceProtocol

--- a/src/lclstreamer/backend/psana1/event_sources.py
+++ b/src/lclstreamer/backend/psana1/event_sources.py
@@ -1,8 +1,13 @@
 import sys
 from collections.abc import Generator
-from typing import Any, cast
+from typing import Any, cast, Optional
 
-from psana import DataSource, MPIDataSource  # type: ignore
+from psana import DataSource # type: ignore
+try:
+    from psana import MPIDataSource
+except ImportError:
+    # this import does not exist in psana2
+    MPIDataSource = None # type: ignore
 from stream.core import source
 
 from ...models.parameters import DataSourceParameters, LclstreamerParameters, Parameters
@@ -88,7 +93,7 @@ class Psana1EventSource(EventSourceProtocol):
     @source
     def get_events(
         self,
-    ) -> Generator[dict[str, StrFloatIntNDArray | None]]:
+    ) -> Generator[Optional[dict[str, StrFloatIntNDArray]]]:
         """
         Retrieves an event from the data source
 

--- a/src/lclstreamer/backend/psana2/data_sources.py
+++ b/src/lclstreamer/backend/psana2/data_sources.py
@@ -1,0 +1,448 @@
+import sys
+from typing import Any, Callable, Optional
+
+import numpy
+from numpy.typing import NDArray
+
+from ...models.parameters import DataSourceParameters
+from ...protocols.backend import DataSourceProtocol
+from ...utils.logging_utils import log
+
+# Note: smalldata provides a "data producer"
+# that shows interfaces to psana2 detectors here:
+# https://github.com/slac-lcls/smalldata_tools/blob/master/lcls2_producers/smd_producer.py
+
+class Psana2Timestamp(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        run: Any,
+    ):
+        """
+        Initializes a psana2 Timestamp data source.
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+        """
+        self.t0 = run.timestamp
+        pass
+
+    def get_data(self, event: Any) -> NDArray[numpy.float_]:
+        """
+        Retrieves timestamp information from a psana2 event
+
+        Arguments:
+
+            event: A psana2 event
+
+        Returns:
+
+            timestamp: a 1D numpy array (of type float64) containing the timestamp
+            information
+        """
+        # note, the timestamp diff may be more helpful
+        # event.timestamp_diff(self.t0)
+
+        # https://confluence.slac.stanford.edu/spaces/LCLSIIData/pages/267391733/psana#psana-Subtractions
+        #timestamp = event.timestamp
+        #upper = (timestamp&0xffffffff00000000)>>32
+        #lower = (timestamp&0xffffffff)
+        #return numpy.array(
+        #    numpy.float64(
+        #        upper + lower*1e-9
+        #    )
+        #)
+        return numpy.array(
+            numpy.float64(
+                    event.timestamp_diff(self.t0)
+                )
+            )
+
+
+class Psana2AreaDetector(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        run: Any,
+    ):
+        """
+        Initializes a psana2 area detector data source.
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+        """
+        extra_parameters: Optional[dict[str, Any]] = parameters.__pydantic_extra__
+
+        if extra_parameters is None:
+            log.error(f"Entries needed by the {name} data source are not defined")
+            sys.exit(1)
+        if "psana_name" not in extra_parameters:
+            log.error(f"Entry 'psana_name' is not defined for data source {name}")
+            sys.exit(1)
+        if "calibration" not in extra_parameters:
+            log.error(f"Entry 'calibration' is not defined for data source {name}")
+            sys.exit(1)
+
+        detector_interface: Any = run.Detector(extra_parameters["psana_name"])
+
+        if extra_parameters["calibration"]:
+            self._data_retrieval_function: Callable[[Any], Any] = (
+                detector_interface.calib
+            )
+        else:
+            self._data_retrieval_function = detector_interface.raw
+
+    def get_data(self, event: Any) -> NDArray[numpy.float_]:
+        """
+        Retrieves a detector frame from a psana2 event
+
+        Arguments:
+
+            event: A psana2 event
+
+         Returns:
+
+            image: A 2d numpy array storing the detector frame as a grayscale
+            image
+        """
+        return numpy.array(self._data_retrieval_function(event), dtype=numpy.float_)
+
+
+class Psana2AssembledAreaDetector(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        run: Any,
+    ):
+        """
+        Initializes a psana2 assembled area detector data source.
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+        """
+        extra_parameters: Optional[dict[str, Any]] = parameters.__pydantic_extra__
+
+        if extra_parameters is None:
+            log.error(f"Entries needed by the {name} data source are not defined")
+            sys.exit(1)
+        if "psana_name" not in extra_parameters:
+            log.error(f"Entry 'psana_name' is not defined for data source {name}")
+            sys.exit(1)
+
+        detector_interface: Any = run.Detector(extra_parameters["psana_name"])
+
+        self._data_retrieval_function = detector_interface.image
+
+    def get_data(self, event: Any) -> NDArray[numpy.float_]:
+        """
+        Retrieves an assembled detector frame from a psana2 event
+
+        Arguments:
+
+            event: A psana2 event
+
+         Returns:
+
+            image: A 2d numpy array storing the assembeld detector frame as a
+            grayscale image
+        """
+        return numpy.array(self._data_retrieval_function(event), dtype=numpy.float_)
+
+
+class Psana2PV(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        run: Any,
+    ):
+        """
+        Initializes a psana2 PV data source.
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+        """
+        extra_parameters: Optional[dict[str, Any]] = parameters.__pydantic_extra__
+
+        if extra_parameters is None:
+            log.error(f"Entries needed by the {name} data source are not defined")
+            sys.exit(1)
+        if "psana_name" not in extra_parameters:
+            log.error(f"Entry 'psana_name' is not defined for data source {name}")
+            sys.exit(1)
+        if "psana_function" in extra_parameters:
+            if extra_parameters["psana_function"] not in ("sum", "channels"):
+                log.error(
+                    "Currently only 'sum' and 'channels' psana_functions are "
+                    "supported (data source {name})"
+                )
+                sys.exit(1)
+
+        self._detector_interface: Any = run.Detector(extra_parameters["psana_name"])
+
+    def get_data(self, event: Any) -> NDArray[numpy.float_]:
+        """
+        Retrieves a PV value from a psana2 event
+
+        Arguments:
+
+            event: A psana2 event
+
+         Returns:
+
+            value: The value of the retrieved data in the format of a numpy float
+            array
+        """
+        return numpy.array(self._detector_interface(event), dtype=numpy.float_)
+
+
+class Psana2BbmonDetectorTotalIntensity(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        run: Any,
+    ):
+        """
+        Initializes a psana2 BbmonDetector data source.
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+        """
+        extra_parameters: Optional[dict[str, Any]] = parameters.__pydantic_extra__
+
+        if extra_parameters is None:
+            log.error(f"Entries needed by the {name} data source are not defined")
+            sys.exit(1)
+        if "psana_name" not in extra_parameters:
+            log.error(f"Entry 'psana_name' is not defined for data source {name}")
+            sys.exit(1)
+
+        self._detector_interface: Any = run.Detector(extra_parameters["psana_name"])
+
+    def get_data(self, event: Any) -> NDArray[numpy.float_]:
+        """
+        Retrieves BmmonDetector data from an event
+
+        Arguments:
+
+            event: A psana2 event
+
+         Returns:
+
+            value: The value of the retrieved data in the format of a numpy float
+            array
+        """
+        return numpy.array(
+            self._detector_interface.get(event).TotalIntensity(), dtype=numpy.float_
+        )
+
+
+class Psana2IpmDetector(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        run: Any,
+    ):
+        """
+        Initializes a psana2 IpmDetector data source.
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+        """
+        extra_parameters: Optional[dict[str, Any]] = parameters.__pydantic_extra__
+
+        if extra_parameters is None:
+            log.error(f"Entries needed by the {name} data source are not defined")
+            sys.exit(1)
+        if "psana_name" not in extra_parameters:
+            log.error(f"Entry 'psana_name' is not defined for data source {name}")
+            sys.exit(1)
+        if "psana_function" not in extra_parameters:
+            log.error(f"Entry 'psana_function' is not defined for data source {name}")
+            sys.exit(1)
+        if extra_parameters["psana_function"] not in ("channel"):
+            log.error(
+                "Currently only the 'channel' psana_functions is supported "
+                "(data source {name})"
+            )
+            sys.exit(1)
+
+        detector_interface: Any = Detector(extra_parameters["psana_name"])
+        self._data_retrieval_function: Callable[[Any], Any] = detector_interface.channel
+
+    def get_data(self, event: Any) -> NDArray[numpy.float_]:
+        """
+        Retrieves IpmDetector data from a psana2 event
+
+        Arguments:
+
+            event: A psana2 event
+
+         Returns:
+
+            value: The value of the retrieved data in the format of a numpy float
+            array
+        """
+        return numpy.array(self._data_retrieval_function(event), dtype=numpy.float_)
+
+
+class Psana2EvrCodes(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        parameters: DataSourceParameters,
+        run: Any,
+    ):
+        """
+        Intializes a psana2 EVR data source
+
+        Arguments:
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+        """
+        extra_parameters: Optional[dict[str, Any]] = parameters.__pydantic_extra__
+        if extra_parameters is None:
+            log.error(f"Entries needed by the {name} data source are not defined")
+            sys.exit(1)
+        if "psana_name" not in extra_parameters:
+            log.error(f"Entry 'psana_name' is not defined for data source {name}")
+            sys.exit(1)
+
+        self._detector_interface: Any = run.Detector(extra_parameters["psana_name"])
+
+    def get_data(self, event: Any) -> NDArray[numpy.int_]:
+        """
+        Retrieves IpmDetector data from an event
+
+        Arguments:
+
+            event: A psana2 event
+
+        Returns:
+
+            value: A numpy array storing all the EVR codes associated with and
+            event (max 256 event codes)
+        """
+        evr_codes: Any = self._detector_interface.eventCodes(event)
+        if evr_codes is None:
+            return numpy.ndarray([0] * 256, dtype=numpy.int_)
+
+        current_evr_codes: NDArray[numpy.int_] = numpy.array(
+            evr_codes, dtype=numpy.int_
+        )
+
+        return numpy.pad(
+            current_evr_codes,
+            pad_width=(0, 256 - len(current_evr_codes)),
+            mode="constant",
+            constant_values=(0, 0),
+        )
+
+
+class Psana2UsdUsbDetector(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        run: Any,
+    ):
+        """
+        Initializes a psana2 UsdUsbDetector data source.
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+        """
+        extra_parameters: Optional[dict[str, Any]] = parameters.__pydantic_extra__
+
+        if extra_parameters is None:
+            log.error(f"Entries needed by the {name} data source are not defined")
+            sys.exit(1)
+        if "psana_name" not in extra_parameters:
+            log.error(f"Entry 'psana_name' is not defined for data source {name}")
+            sys.exit(1)
+        if "psana_function" not in extra_parameters:
+            log.error(f"Entry 'psana_function' is not defined for data source {name}")
+            sys.exit(1)
+        if extra_parameters["psana_function"] not in ("values"):
+            log.error(
+                "Currently only the 'channel' psana_functions is supported "
+                "(data source {name})"
+            )
+            sys.exit(1)
+        detector_interface: Any = run.Detector(extra_parameters["psana_name"])
+        self._data_retrieval_function: Callable[[Any], Any] = detector_interface.values
+
+    def get_data(self, event: Any) -> NDArray[numpy.float_]:
+        """
+        Retrieves UsdUsbDetector data from a psana2 event
+
+        Arguments:
+
+            event: A psana2 event
+
+         Returns:
+
+            value: The value of the retrieved data in the format of a numpy float
+            array
+        """
+        return numpy.array(self._data_retrieval_function(event), dtype=numpy.float_)

--- a/src/lclstreamer/cmd/lclstreamer.py
+++ b/src/lclstreamer/cmd/lclstreamer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import (
     Annotated,
     Any,
+    Optional,
 )
 
 import typer
@@ -31,8 +32,8 @@ app = typer.Typer()
 
 @stream
 def filter_incomplete_events(
-    events: Iterator[dict[str, StrFloatIntNDArray | None]], max_consecutive: int = 100
-) -> Iterator[dict[str, StrFloatIntNDArray | None]]:
+    events: Iterator[dict[str, Optional[StrFloatIntNDArray]]], max_consecutive: int = 100
+) -> Iterator[dict[str, Optional[StrFloatIntNDArray]]]:
     """
     Ddrops events that are incomplete
 

--- a/src/lclstreamer/cmd/lclstreamer.py
+++ b/src/lclstreamer/cmd/lclstreamer.py
@@ -51,18 +51,22 @@ def filter_incomplete_events(
     consecutive: int = 0
     ev_num: int = 0
     num_dropped: int = 0
+    nfailed: dict[str, int] = {} # number from each detector
     for ev_num, event in enumerate(events):
-        if None not in event.values():
+        if all(v is not None for v in event.values()):
             yield event
             consecutive = 0
             continue
+        for name, v in event.items():
+            if v is None:
+                nfailed[name] = nfailed.get(name, 0)+1
         consecutive += 1
         num_dropped += 1
         if consecutive >= max_consecutive:
             break
     if consecutive >= max_consecutive:
         print(f"Stopping early at event {ev_num} after {consecutive} errors")
-        print("Failed detector list:")
+        print(f"Failed detector counts: {nfailed}")
     print(f"Processed {ev_num} events with {num_dropped} dropped")
 
 

--- a/src/lclstreamer/frontend/processing_pipelines/utils.py
+++ b/src/lclstreamer/frontend/processing_pipelines/utils.py
@@ -35,7 +35,7 @@ class DataStorage:
 
         self._data_containers: dict[str, DataContainer] = {}
 
-    def add_data(self, data: dict[str, StrFloatIntNDArray | None]) -> None:
+    def add_data(self, data: dict[str, Optional[StrFloatIntNDArray]]) -> None:
         """
         Adds data to the Data Storage object
 

--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Literal, Optional, Self
+from typing import Literal, Optional
+Self = "Self"
 
 from pydantic import BaseModel, ConfigDict, model_validator
 

--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -12,6 +12,7 @@ class CustomBaseModel(BaseModel):
 
 
 class Psana1EventSourceParameters(CustomBaseModel): ...  # noqa: E701
+class Psana2EventSourceParameters(CustomBaseModel): ...  # noqa: E701
 
 
 class HDF5SerializerParameters(CustomBaseModel):
@@ -49,8 +50,14 @@ class DataSourceParameters(CustomBaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class SourceIdentifier(CustomBaseModel):
+    exp: str
+    run: int
+    shmem: bool = False
+
+
 class LclstreamerParameters(CustomBaseModel):
-    source_identifier: str
+    source_identifier: SourceIdentifier
     batch_size: int
     event_source: str
     processing_pipeline: str
@@ -62,6 +69,7 @@ class LclstreamerParameters(CustomBaseModel):
 class EventSourceParameters(CustomBaseModel):
 
     Psana1EventSource: Optional[Psana1EventSourceParameters] = None
+    Psana2EventSource: Optional[Psana2EventSourceParameters] = None
 
 
 class ProcessingPipelineParameters(CustomBaseModel):

--- a/src/lclstreamer/protocols/backend.py
+++ b/src/lclstreamer/protocols/backend.py
@@ -44,6 +44,7 @@ class DataSourceProtocol(Protocol):
         self,
         name: str,
         parameters: DataSourceParameters,
+        run: Any,
     ):
         """Initializes the data source"""
         ...

--- a/src/lclstreamer/protocols/backend.py
+++ b/src/lclstreamer/protocols/backend.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import numpy
 from numpy.typing import NDArray
@@ -8,7 +8,7 @@ from typing_extensions import Protocol, TypeAlias
 
 from ..models.parameters import DataSourceParameters, Parameters
 
-StrFloatIntNDArray: TypeAlias = NDArray[numpy.str_ | numpy.float_ | numpy.int_]
+StrFloatIntNDArray: TypeAlias = Union[NDArray[numpy.str_],NDArray[numpy.float_],NDArray[numpy.int_]]
 
 
 class EventSourceProtocol(Protocol):


### PR DESCRIPTION
These changes add basic psana2 support.  I ran these with a pip install inside venv created based on the psana2 conda env on s3df.

    source /sdf/group/lcls/ds/ana/sw/conda2/manage/bin/psconda.sh
    . /sdf/home/r/rogersdd/src/tmox1016823/venv/bin/activate

It required python3.9, so some of the syntax was downgraded.
The psana2 backend  also required adding "run" as a parameter in DataSourceProtocol (to get run.Detector).

There's an additional change to make the source identifier more verbose:
```
class SourceIdentifier(CustomBaseModel):
    exp: str
    run: int
    shmem: bool = False

class LclstreamerParameters(CustomBaseModel):
    source_identifier: SourceIdentifier
```
