### PR TITLE
Features/simplon

### DIFF
--- a/examples/lclstreamer-psana2-simplon.yml
+++ b/examples/lclstreamer-psana2-simplon.yml
@@ -24,6 +24,28 @@ data_sources:
         type: Psana2PV
         psana_name: "SIOC:SYS0:ML00:AO192"
 
+    detector_info:
+        type: Psana2DetectorValues
+        psana_name: "jungfrau"
+        psana_fields: [
+            "_det_name",   # Detector name
+            "_dettype",    # Detector type
+            "_detid"       # Detector ID
+        ]
+
+    beam_pointing:
+        type: Psana2DetectorValues
+        psana_name: "ebeamh"
+        psana_fields: [
+            "raw.ebeamUndAngX", # Angle X
+            "raw.ebeamUndAngY", # Angle Y
+            "raw.ebeamUndPosX", # Pos X
+            "raw.ebeamUndPosY"  # Pos Y
+        ]
+
+    run_info:
+        type: Psana2RunInfo
+
 event_source:
     Psana2EventSource: {}
 
@@ -34,6 +56,8 @@ processing_pipeline:
 data_serializer:
     SimplonBinarySerializer:
         data_source_to_serialize: detector_data
+        polarization_fraction: 0
+        polarization_axis: [1.0, 0.0, 0.0]
 
 data_handlers:
     BinaryDataStreamingDataHandler:

--- a/examples/lclstreamer-psana2-simplon.yml
+++ b/examples/lclstreamer-psana2-simplon.yml
@@ -24,25 +24,23 @@ data_sources:
         type: Psana2PV
         psana_name: "SIOC:SYS0:ML00:AO192"
 
-    detector_info:
-        type: Psana2DetectorValues
+    detector_geometry:
+        type: Psana2DetectorInterface
         psana_name: "jungfrau"
         psana_fields: [
-            "_det_name",                  # Detector name
-            "_dettype",                   # Detector type
             "_detid",                     # Detector ID
-            "raw._det_geotxt_default",    # Geometry data
-            "raw._pixel_coords"           # Pixel coordinates
+            "raw._det_geotxt_default"     # Geometry data
+            #"raw._pixel_coords"          # Pixel coordinates (optional)
         ]
 
-    beam_pointing:
-        type: Psana2DetectorValues
+    beam_pointing:                     # Optional
+        type: Psana2DetectorInterface
         psana_name: "ebeamh"
         psana_fields: [
-            "raw.ebeamUndAngX", # Angle X
-            "raw.ebeamUndAngY", # Angle Y
-            "raw.ebeamUndPosX", # Pos X
-            "raw.ebeamUndPosY"  # Pos Y
+            "raw.ebeamUndAngX",        # Angle X
+            "raw.ebeamUndAngY",        # Angle Y
+            "raw.ebeamUndPosX",        # Pos X
+            "raw.ebeamUndPosY"         # Pos Y
         ]
 
     run_info:
@@ -61,6 +59,8 @@ data_serializer:
         polarization_fraction: 0
         polarization_axis: [1.0, 0.0, 0.0]
         data_collection_rate: "120Hz"
+        detector_name: "jungfrau"
+        detector_type: "AreaDetector"
 
 data_handlers:
     BinaryDataStreamingDataHandler:

--- a/examples/lclstreamer-psana2-simplon.yml
+++ b/examples/lclstreamer-psana2-simplon.yml
@@ -28,9 +28,11 @@ data_sources:
         type: Psana2DetectorValues
         psana_name: "jungfrau"
         psana_fields: [
-            "_det_name",   # Detector name
-            "_dettype",    # Detector type
-            "_detid"       # Detector ID
+            "_det_name",                  # Detector name
+            "_dettype",                   # Detector type
+            "_detid",                     # Detector ID
+            "raw._det_geotxt_default",    # Geometry data
+            "raw._pixel_coords"           # Pixel coordinates
         ]
 
     beam_pointing:
@@ -58,6 +60,7 @@ data_serializer:
         data_source_to_serialize: detector_data
         polarization_fraction: 0
         polarization_axis: [1.0, 0.0, 0.0]
+        data_collection_rate: "120Hz"
 
 data_handlers:
     BinaryDataStreamingDataHandler:

--- a/src/lclstreamer/backend/psana2/data_sources.py
+++ b/src/lclstreamer/backend/psana2/data_sources.py
@@ -441,7 +441,7 @@ class Psana2HsdDetector(DataSourceProtocol):
         return numpy.array(self._data_retrieval_function(event), dtype=numpy.float_)
 
 
-class Psana2DetectorValues(DataSourceProtocol):
+class Psana2DetectorInterface(DataSourceProtocol):
     """
     See documentation of the `__init__` function.
     """

--- a/src/lclstreamer/backend/psana2/data_sources.py
+++ b/src/lclstreamer/backend/psana2/data_sources.py
@@ -480,7 +480,7 @@ class Psana2DetectorValues(DataSourceProtocol):
         for fields in extra_parameters["psana_fields"]:
             self._det_params.append(fields)
 
-    def get_data(self, event: Any) -> NDArray[numpy.str_]:
+    def get_data(self, event: Any) -> NDArray[object]:
         """
         Retrieves Detector values from a psana2 event
 
@@ -490,9 +490,9 @@ class Psana2DetectorValues(DataSourceProtocol):
 
          Returns:
 
-            value: The retrieved data is a list, such as:
-            [Value1, Value2, Value3, ...]
-            in the format of a numpy string array.
+            value: The retrieved data is a list of object, such as:
+            [Object1, Object2, Object3, ...]
+            in the format of a numpy array.
         """
 
         data = []
@@ -506,9 +506,15 @@ class Psana2DetectorValues(DataSourceProtocol):
                 else:
                     log.error(f"Detector {base} has no parameter {field}")
                     sys.exit(1)
-            data.append(str(base(event)) if callable(base) else str(base))
-
-        return numpy.array(data, dtype=numpy.str_)
+            if callable(base):
+                try:
+                    res = base(event)
+                except TypeError:
+                    res = base()
+                data.append(res)
+            else:
+                data.append(base)
+        return numpy.array(data, dtype=object)
 
 
 class Psana2RunInfo(DataSourceProtocol):

--- a/src/lclstreamer/backend/psana2/event_sources.py
+++ b/src/lclstreamer/backend/psana2/event_sources.py
@@ -17,10 +17,12 @@ from .data_sources import (  # noqa: F401
     Psana2AreaDetector,
     Psana2AssembledAreaDetector,
     Psana2Camera,
+    Psana2DetectorValues,
     Psana2EBeam,
     Psana2Gmd,
     Psana2HsdDetector,
     Psana2PV,
+    Psana2RunInfo,
     Psana2Timestamp,
 )
 

--- a/src/lclstreamer/backend/psana2/event_sources.py
+++ b/src/lclstreamer/backend/psana2/event_sources.py
@@ -17,7 +17,7 @@ from .data_sources import (  # noqa: F401
     Psana2AreaDetector,
     Psana2AssembledAreaDetector,
     Psana2Camera,
-    Psana2DetectorValues,
+    Psana2DetectorInterface,
     Psana2EBeam,
     Psana2Gmd,
     Psana2HsdDetector,

--- a/src/lclstreamer/cmd/lclstreamer.py
+++ b/src/lclstreamer/cmd/lclstreamer.py
@@ -149,11 +149,11 @@ def main(
         workflow >>= filter_incomplete_events(max_consecutive=1)
 
     workflow >>= processing_pipeline
-    
+
     workflow = Source(workflow)
 
     workflow >>= data_serializer
-    
+
     workflow = Source(workflow)
 
     data_handler: DataHandlerProtocol

--- a/src/lclstreamer/cmd/lclstreamer.py
+++ b/src/lclstreamer/cmd/lclstreamer.py
@@ -34,7 +34,7 @@ def filter_incomplete_events(
     events: Iterator[dict[str, StrFloatIntNDArray | None]], max_consecutive: int = 100
 ) -> Iterator[dict[str, StrFloatIntNDArray | None]]:
     """
-    Ddrops events that are incomplete
+    Drops events that are incomplete
 
     Incomplete events are events where the retrieval of one or more data items
     failed.

--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -24,6 +24,7 @@ class SimplonBinarySerializerParameters(CustomBaseModel):
     data_source_to_serialize: str
     polarization_fraction: float
     polarization_axis: list[float]
+    data_collection_rate: str
 
 
 class HDF5BinarySerializerParameters(CustomBaseModel):

--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -22,6 +22,8 @@ class Psana2EventSourceParameters(CustomBaseModel): ...  # noqa: E701
 
 class SimplonBinarySerializerParameters(CustomBaseModel):
     data_source_to_serialize: str
+    polarization_fraction: float
+    polarization_axis: list[float]
 
 
 class HDF5BinarySerializerParameters(CustomBaseModel):


### PR DESCRIPTION
New data sources:
1. Psana2DetectorValues fetches any field from a detector object that is listed in the yaml file.
2. Psana2Runinfo Fetches source identifier, run number, run timestamp etc.

Example **start** message:

```
{
  "type": "start",
  "run_number": "355",
  "start_time": 4802939555773225093,
  "duration": "N/A",
  "beamline": "MFX",
  "experiment": "mfx100852324",
  "beam_type": "X-ray",
  "polarization":
  {
    "fraction": 0.0,
    "axis":
    [
      1.0,
      0.0,
      0.0
    ]
  }  
  "data_collection_rate": "120Hz",
  "datatype": "float64",
  "shape": "32x512x1024",
  "algorithm": "bitshuffle-lz4",
  "detector":
  {
    "name": "jungfrau",
    "id": "9000000000000-230921-3007f0239",
    "type": "jungfrau",
    "geometry": "# TITLE   Geometry parameters of Jungfrau\n# DATE_TIME  2025-03-12 09:30:00 PDT\n# METROLOGY  no metrology available\n# AUTHOR    dubrovin\n# EXPERIMENT any\n# DETECTOR   jungfrau16M\n# CALIB_TYPE geometry\n# COMMENT:01 Manually created as an example for the 832-segment Jungfrau16M detector\n# COMMENT:02.... etc"
    "pixel_coords": [Array of pixel coords, too large to display],
     "material": "???",
    "thickness": "???"
  },
  "photon_wavelength": 0.10675205824441208,
  "message_id": 1,
  "timestamp": 1758322389.3556495
}
```

Example **main (image)** message:
```
{
  "type": "image",
  "run": "355",
  "compressed_data": [Array of the data compressed],
  "beam_direction": {
    "angle_x": 0.0006593805737793446,
    "angle_y": -0.0011653333203867078,
    "position_x": 0.0013882643543183804,
    "position_y": -0.005508349277079105
   },
   "dtype": "float64",
   "sum": [Sum of the array],
   "message_id": 2,
   "timestamp": 1758322389.3556495
 }
 ```                                   
Changes from previous: beam direction is now moved to the per event message as it takes event as the argument.
Missing: Material, thickness

Relevant yaml parameters

```
detector_info:
  type: Psana2DetectorValues
  psana_name: "jungfrau"
  psana_fields: [
      "_det_name",                  # Detector name
      "_dettype",                   # Detector type
      "_detid",                     # Detector ID
      "raw._det_geotxt_default",    # Geometry data
      "raw._pixel_coords"           # Pixel coordinates
   ]

beam_pointing:
  type: Psana2DetectorValues
  psana_name: "ebeamh"
  psana_fields: [
    "raw.ebeamUndAngX", # Angle X
    "raw.ebeamUndAngY", # Angle Y
    "raw.ebeamUndPosX", # Pos X
    "raw.ebeamUndPosY"  # Pos Y
  ]
```

These values are hardcoded for now, I am not sure where this comes from, I could not find anything in psana that returns polarization info. But they can enter this manually in the yaml file to go with the data, same with the repetition rate.

```
data_serializer:
  SimplonBinarySerializer:
      data_source_to_serialize: detector_data
      polarization_fraction: 0
      polarization_axis: [1.0, 0.0, 0.0]
      data_collection_rate: "120Hz"
```