### PR TITLE
Add image preprocessing pipeline for PeakNet integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This architecture enables real-time producer-consumer data processing pipelines,
 **Example setup**:
 ```bash
 # 1. Start sink node first (server - auto-detects hostname, uses default port)
-python examples/psana_pull_script.py
+python examples/psana_pull_script_inspect.py
 
 # 2. Update configuration file with actual sink node hostname and port
 # Edit examples/lclstreamer-psana1-to-sdfada.yaml:
@@ -81,7 +81,7 @@ pixi run --environment psana1 mpirun -n 8 lclstreamer --config examples/lclstrea
 
 **Note**: When using SLURM, update the sink node URL in your configuration file to match the hostname of the node allocated for your sink job. Both hostname and port can be customized using `--hostname` and `--port` options if needed.
 
-The pull script (`examples/psana_pull_script.py`) auto-detects the hostname and provides comprehensive data inspection with configurable network endpoints for flexible deployment across heterogeneous computing environments.
+Use `examples/psana_pull_script.py` for basic HDF5 data reception, or `examples/psana_pull_script_inspect.py` for comprehensive data inspection with hostname auto-detection and configurable network endpoints for flexible deployment across heterogeneous computing environments.
 
 ### Deployment
 

--- a/examples/lclstreamer-psana1-to-sdfada-with-preprocessing.yaml
+++ b/examples/lclstreamer-psana1-to-sdfada-with-preprocessing.yaml
@@ -1,7 +1,7 @@
 lclstreamer:
     source_identifier: exp=mfx100903824:run=27
     event_source: Psana1EventSource
-    processing_pipeline: PreprocessingBatchPipeline
+    processing_pipeline: PeaknetPreprocessingPipeline
     data_serializer: Hdf5BinarySerializer
     skip_incomplete_events: false
     data_handlers:
@@ -28,7 +28,7 @@ event_source:
     Psana1EventSource: {}
 
 processing_pipeline:
-    PreprocessingBatchPipeline:
+    PeaknetPreprocessingPipeline:
         batch_size: 16
         target_height: 2048
         target_width: 2048

--- a/examples/lclstreamer-psana1-to-sdfada-with-preprocessing.yaml
+++ b/examples/lclstreamer-psana1-to-sdfada-with-preprocessing.yaml
@@ -15,6 +15,10 @@ data_sources:
         type: Psana1AssembledAreaDetector
         psana_name: epix10k2M
 
+    random:
+        type: GenericRandomNumpyArray
+        array_shape: 4,4,4
+        array_dtype: float32
 
     photon_wavelength:
         type: Psana1PV
@@ -26,8 +30,8 @@ event_source:
 processing_pipeline:
     PreprocessingBatchPipeline:
         batch_size: 16
-        target_height: 1920
-        target_width: 1920
+        target_height: 2048
+        target_width: 2048
         pad_style: center
         add_channel_dim: true
         num_channels: 1
@@ -39,6 +43,7 @@ data_serializer:
         fields:
             timestamp: /data/timestamp
             detector_data: /data/data
+            random: /data/random
             photon_wavelength: /data/wavelength
 
 data_handlers:

--- a/examples/lclstreamer-psana1-to-sdfada.yaml
+++ b/examples/lclstreamer-psana1-to-sdfada.yaml
@@ -1,7 +1,7 @@
 lclstreamer:
     source_identifier: exp=mfx100903824:run=27
     event_source: Psana1EventSource
-    processing_pipeline: PreprocessingBatchPipeline
+    processing_pipeline: PeaknetPreprocessingPipeline
     data_serializer: Hdf5BinarySerializer
     skip_incomplete_events: false
     data_handlers:
@@ -24,7 +24,7 @@ event_source:
     Psana1EventSource: {}
 
 processing_pipeline:
-    PreprocessingBatchPipeline:
+    PeaknetPreprocessingPipeline:
         batch_size: 16
         target_height: 1920
         target_width: 1920

--- a/examples/lclstreamer-psana1-to-sdfada.yaml
+++ b/examples/lclstreamer-psana1-to-sdfada.yaml
@@ -1,0 +1,57 @@
+lclstreamer:
+    source_identifier: exp=xpptut15:run=430
+    event_source: Psana1EventSource
+    processing_pipeline: BatchProcessingPipeline
+    data_serializer: Hdf5BinarySerializer
+    skip_incomplete_events: false
+    data_handlers:
+        - BinaryFileWritingDataHandler
+        - BinaryDataStreamingDataHandler
+
+data_sources:
+    timestamp:
+        type: Psana1Timestamp
+
+    detector_data:
+        type: Psana1AreaDetector
+        psana_name: Jungfrau1M
+        calibration: true
+
+    random:
+        type: GenericRandomNumpyArray
+        array_shape: 4,4,4
+        array_dtype: float32
+
+    photon_wavelength:
+        type: Psana1PV
+        psana_name: "SIOC:SYS0:ML00:AO192"
+
+event_source:
+    Psana1EventSource: {}
+
+processing_pipeline:
+    BatchProcessingPipeline:
+        batch_size: 10
+
+data_serializer:
+    Hdf5BinarySerializer:
+        compression_level: 3
+        compression: zfp
+        fields:
+            timestamp: /data/timestamp
+            detector_data: /data/data
+            random: /data/random
+            photon_wavelength: /data/wavelength
+
+data_handlers:
+    BinaryFileWritingDataHandler:
+        file_prefix: ""
+        file_suffix: h5
+        write_directory: workspace/output
+
+    BinaryDataStreamingDataHandler:
+        urls:
+            - "tcp://sdfada003:12321"
+        role: client
+        library: nng
+        socket_type: push

--- a/examples/psana_pull_script.py
+++ b/examples/psana_pull_script.py
@@ -1,16 +1,66 @@
+import argparse
+import socket
 import sys
 from io import BytesIO
 
 import h5py  # type: ignore
+import hdf5plugin  # type: ignore
 from pynng import Pull0  # type: ignore
 
-socket = Pull0(listen="tcp://127.0.0.1:12321")
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Pull HDF5 data from LCLStreamer data source clients")
+parser.add_argument("--hostname", default=socket.gethostname(), 
+                    help="Hostname to listen on (default: auto-detect)")
+parser.add_argument("--port", type=int, default=12321,
+                    help="Port to listen on (default: 12321)")
+args = parser.parse_args()
+
+# Listen as server to receive data from multiple MPI clients
+listen_address = f"tcp://{args.hostname}:{args.port}"
+print(f"Listening on {listen_address}")
+pull_socket = Pull0(listen=listen_address)
+
 count = 0
 while True:
-    msg = socket.recv()
+    msg = pull_socket.recv()
     fh = h5py.File(BytesIO(msg))
-    content = fh[fh["/"].keys()[0]][:].shape[0]
+
+    # Print available datasets in the HDF5 structure
+    print(f"Available datasets: {list(fh.keys())}")
+
+    # Access the data based on the configured HDF5 field mapping
+    if '/data/data' in fh:  # detector_data
+        dataset = fh['/data/data']
+        print(f"Dataset info: compression={dataset.compression}, shape={dataset.shape}")
+        try:
+            detector_shape = dataset[:].shape
+            print(f"Detector data shape: {detector_shape}")
+        except OSError as e:
+            print(f"Error reading data: {e}")
+            print("Trying to read without loading full array...")
+            print(f"Dataset shape: {dataset.shape}, dtype: {dataset.dtype}")
+
+    if '/data/wavelength' in fh:  # photon_wavelength
+        wavelength = fh['/data/wavelength'][:]
+        print(f"Photon wavelength: {wavelength}")
+
+    if '/data/timestamp' in fh:  # timestamp
+        timestamp = fh['/data/timestamp'][:]
+        print(f"Timestamp: {timestamp}")
+
+    if '/data/random' in fh:  # random array
+        random_shape = fh['/data/random'][:].shape
+        print(f"Random array shape: {random_shape}")
+
+    # Fallback to original logic for other data structures
+    if '/data/data' not in fh and fh["/"].keys():
+        first_key = list(fh["/"].keys())[0]
+        content = fh[first_key][:].shape[0]
+        count += content
+        print(f"Received {count} messages from dataset: {first_key}")
+
     fh.close()
-    count += content
-    print(f"Received {count} messages")
+    count += 1
+    print(f"Received {count} data packets")
+    print("-" * 40)
     sys.stdout.flush()

--- a/examples/psana_pull_script.py
+++ b/examples/psana_pull_script.py
@@ -1,66 +1,16 @@
-import argparse
-import socket
 import sys
 from io import BytesIO
 
 import h5py  # type: ignore
-import hdf5plugin  # type: ignore
 from pynng import Pull0  # type: ignore
 
-# Parse command line arguments
-parser = argparse.ArgumentParser(description="Pull HDF5 data from LCLStreamer data source clients")
-parser.add_argument("--hostname", default=socket.gethostname(), 
-                    help="Hostname to listen on (default: auto-detect)")
-parser.add_argument("--port", type=int, default=12321,
-                    help="Port to listen on (default: 12321)")
-args = parser.parse_args()
-
-# Listen as server to receive data from multiple MPI clients
-listen_address = f"tcp://{args.hostname}:{args.port}"
-print(f"Listening on {listen_address}")
-pull_socket = Pull0(listen=listen_address)
-
+socket = Pull0(listen="tcp://127.0.0.1:12321")
 count = 0
 while True:
-    msg = pull_socket.recv()
+    msg = socket.recv()
     fh = h5py.File(BytesIO(msg))
-
-    # Print available datasets in the HDF5 structure
-    print(f"Available datasets: {list(fh.keys())}")
-
-    # Access the data based on the configured HDF5 field mapping
-    if '/data/data' in fh:  # detector_data
-        dataset = fh['/data/data']
-        print(f"Dataset info: compression={dataset.compression}, shape={dataset.shape}")
-        try:
-            detector_shape = dataset[:].shape
-            print(f"Detector data shape: {detector_shape}")
-        except OSError as e:
-            print(f"Error reading data: {e}")
-            print("Trying to read without loading full array...")
-            print(f"Dataset shape: {dataset.shape}, dtype: {dataset.dtype}")
-
-    if '/data/wavelength' in fh:  # photon_wavelength
-        wavelength = fh['/data/wavelength'][:]
-        print(f"Photon wavelength: {wavelength}")
-
-    if '/data/timestamp' in fh:  # timestamp
-        timestamp = fh['/data/timestamp'][:]
-        print(f"Timestamp: {timestamp}")
-
-    if '/data/random' in fh:  # random array
-        random_shape = fh['/data/random'][:].shape
-        print(f"Random array shape: {random_shape}")
-
-    # Fallback to original logic for other data structures
-    if '/data/data' not in fh and fh["/"].keys():
-        first_key = list(fh["/"].keys())[0]
-        content = fh[first_key][:].shape[0]
-        count += content
-        print(f"Received {count} messages from dataset: {first_key}")
-
+    content = fh[fh["/"].keys()[0]][:].shape[0]
     fh.close()
-    count += 1
-    print(f"Received {count} data packets")
-    print("-" * 40)
+    count += content
+    print(f"Received {count} messages")
     sys.stdout.flush()

--- a/examples/psana_pull_script_inspect.py
+++ b/examples/psana_pull_script_inspect.py
@@ -1,0 +1,66 @@
+import argparse
+import socket
+import sys
+from io import BytesIO
+
+import h5py  # type: ignore
+import hdf5plugin  # type: ignore
+from pynng import Pull0  # type: ignore
+
+# Parse command line arguments
+parser = argparse.ArgumentParser(description="Pull HDF5 data from LCLStreamer data source clients")
+parser.add_argument("--hostname", default=socket.gethostname(), 
+                    help="Hostname to listen on (default: auto-detect)")
+parser.add_argument("--port", type=int, default=12321,
+                    help="Port to listen on (default: 12321)")
+args = parser.parse_args()
+
+# Listen as server to receive data from multiple MPI clients
+listen_address = f"tcp://{args.hostname}:{args.port}"
+print(f"Listening on {listen_address}")
+pull_socket = Pull0(listen=listen_address)
+
+count = 0
+while True:
+    msg = pull_socket.recv()
+    fh = h5py.File(BytesIO(msg))
+
+    # Print available datasets in the HDF5 structure
+    print(f"Available datasets: {list(fh.keys())}")
+
+    # Access the data based on the configured HDF5 field mapping
+    if '/data/data' in fh:  # detector_data
+        dataset = fh['/data/data']
+        print(f"Dataset info: compression={dataset.compression}, shape={dataset.shape}")
+        try:
+            detector_shape = dataset[:].shape
+            print(f"Detector data shape: {detector_shape}")
+        except OSError as e:
+            print(f"Error reading data: {e}")
+            print("Trying to read without loading full array...")
+            print(f"Dataset shape: {dataset.shape}, dtype: {dataset.dtype}")
+
+    if '/data/wavelength' in fh:  # photon_wavelength
+        wavelength = fh['/data/wavelength'][:]
+        print(f"Photon wavelength: {wavelength}")
+
+    if '/data/timestamp' in fh:  # timestamp
+        timestamp = fh['/data/timestamp'][:]
+        print(f"Timestamp: {timestamp}")
+
+    if '/data/random' in fh:  # random array
+        random_shape = fh['/data/random'][:].shape
+        print(f"Random array shape: {random_shape}")
+
+    # Fallback to original logic for other data structures
+    if '/data/data' not in fh and fh["/"].keys():
+        first_key = list(fh["/"].keys())[0]
+        content = fh[first_key][:].shape[0]
+        count += content
+        print(f"Received {count} messages from dataset: {first_key}")
+
+    fh.close()
+    count += 1
+    print(f"Received {count} data packets")
+    print("-" * 40)
+    sys.stdout.flush()

--- a/src/lclstreamer/frontend/processing_pipeline.py
+++ b/src/lclstreamer/frontend/processing_pipeline.py
@@ -5,7 +5,7 @@ from ..protocols.frontend import ProcessingPipelineProtocol
 from ..utils.logging_utils import log
 from .processing_pipelines.generic import (  # noqa: F401
     BatchProcessingPipeline,
-    PreprocessingBatchPipeline,
+    PeaknetPreprocessingPipeline,
 )
 
 

--- a/src/lclstreamer/frontend/processing_pipeline.py
+++ b/src/lclstreamer/frontend/processing_pipeline.py
@@ -5,6 +5,7 @@ from ..protocols.frontend import ProcessingPipelineProtocol
 from ..utils.logging_utils import log
 from .processing_pipelines.generic import (  # noqa: F401
     BatchProcessingPipeline,
+    PreprocessingBatchPipeline,
 )
 
 

--- a/src/lclstreamer/frontend/processing_pipelines/generic.py
+++ b/src/lclstreamer/frontend/processing_pipelines/generic.py
@@ -5,6 +5,7 @@ from ...models.parameters import ProcessingPipelineParameters
 from ...protocols.backend import StrFloatIntNDArray
 from ...protocols.frontend import ProcessingPipelineProtocol
 from ...utils.logging_utils import log
+from .preprocessing import NumpyPad, add_channel_dimension
 from .utils import DataStorage
 
 
@@ -52,3 +53,128 @@ class BatchProcessingPipeline(ProcessingPipelineProtocol):
 
         if len(data_storage) > 0:
             yield data_storage.retrieve_stored_data()
+
+
+class PreprocessingBatchPipeline(ProcessingPipelineProtocol):
+    """
+    A processing pipeline that applies preprocessing (padding, channel dimension) and batching.
+
+    This pipeline performs the following operations in order:
+    1. Pad individual images to target size (before batching)
+    2. Batch the padded images
+    3. Add channel dimension to batched data (after batching)
+
+    The preprocessing is applied to detector image data while other data types
+    (timestamps, scalars, etc.) are passed through unchanged.
+    """
+
+    def __init__(self, parameters: ProcessingPipelineParameters) -> None:
+        """
+        Initializes a preprocessing batch pipeline.
+
+        Arguments:
+            parameters: The configuration parameters
+        """
+        if parameters.PreprocessingBatchPipeline is None:
+            log.error("No configuration parameters found for PreprocessingBatchPipeline")
+            sys.exit(1)
+
+        config = parameters.PreprocessingBatchPipeline
+        self._batch_size: int = config.batch_size
+
+        # Initialize padding utility
+        self._padder = NumpyPad(
+            target_height=config.target_height,
+            target_width=config.target_width,
+            pad_style=config.pad_style
+        )
+
+        # Channel dimension settings
+        self._add_channel_dim: bool = config.add_channel_dim
+        self._num_channels: int = config.num_channels
+
+    def _is_image_data(self, data_key: str, data_value: StrFloatIntNDArray | None) -> bool:
+        """
+        Determine if a data entry represents image data that should be preprocessed.
+
+        Args:
+            data_key: The key/name of the data entry
+            data_value: The data array
+
+        Returns:
+            True if this looks like image data that should be preprocessed
+        """
+        if data_value is None:
+            return False
+
+        # Heuristic: 2D arrays are likely images
+        # You may want to refine this logic based on your specific data keys
+        return len(data_value.shape) == 2
+
+    def __call__(
+        self, stream: Iterator[dict[str, StrFloatIntNDArray | None]]
+    ) -> Iterator[dict[str, StrFloatIntNDArray | None]]:
+        """
+        Process the data stream with preprocessing and batching.
+
+        Arguments:
+            stream: Iterator of data events
+
+        Returns:
+            Iterator of preprocessed and batched data events
+        """
+        data_storage: DataStorage = DataStorage()
+
+        data: dict[str, StrFloatIntNDArray | None]
+        for data in stream:
+            # Apply preprocessing to image data before adding to batch
+            preprocessed_data = {}
+
+            for data_key, data_value in data.items():
+                if self._is_image_data(data_key, data_value):
+                    # Apply padding to image data
+                    preprocessed_data[data_key] = self._padder(data_value)
+                else:
+                    # Pass through non-image data unchanged
+                    preprocessed_data[data_key] = data_value
+
+            data_storage.add_data(data=preprocessed_data)
+
+            if len(data_storage) >= self._batch_size:
+                batched_data = data_storage.retrieve_stored_data()
+
+                # Add channel dimension to image data after batching
+                if self._add_channel_dim:
+                    final_data = {}
+                    for data_key, batch_value in batched_data.items():
+                        if batch_value is not None and len(batch_value.shape) == 3:
+                            # This is batched image data (B, H, W) -> add channel (B, C, H, W)
+                            final_data[data_key] = add_channel_dimension(
+                                batch_value, self._num_channels
+                            )
+                        else:
+                            # Pass through non-image data
+                            final_data[data_key] = batch_value
+                    yield final_data
+                else:
+                    yield batched_data
+
+                data_storage.reset_data_storage()
+
+        # Handle remaining data
+        if len(data_storage) > 0:
+            batched_data = data_storage.retrieve_stored_data()
+
+            # Add channel dimension to remaining data if configured
+            if self._add_channel_dim:
+                final_data = {}
+                for data_key, batch_value in batched_data.items():
+                    if batch_value is not None and len(batch_value.shape) == 3:
+                        final_data[data_key] = add_channel_dimension(
+                            batch_value, self._num_channels
+                        )
+                    else:
+                        final_data[data_key] = batch_value
+                yield final_data
+            else:
+                yield batched_data

--- a/src/lclstreamer/frontend/processing_pipelines/generic.py
+++ b/src/lclstreamer/frontend/processing_pipelines/generic.py
@@ -55,7 +55,7 @@ class BatchProcessingPipeline(ProcessingPipelineProtocol):
             yield data_storage.retrieve_stored_data()
 
 
-class PreprocessingBatchPipeline(ProcessingPipelineProtocol):
+class PeaknetPreprocessingPipeline(ProcessingPipelineProtocol):
     """
     A processing pipeline that applies preprocessing (padding, channel dimension) and batching.
 
@@ -70,16 +70,16 @@ class PreprocessingBatchPipeline(ProcessingPipelineProtocol):
 
     def __init__(self, parameters: ProcessingPipelineParameters) -> None:
         """
-        Initializes a preprocessing batch pipeline.
+        Initializes a PeakNet preprocessing pipeline.
 
         Arguments:
             parameters: The configuration parameters
         """
-        if parameters.PreprocessingBatchPipeline is None:
-            log.error("No configuration parameters found for PreprocessingBatchPipeline")
+        if parameters.PeaknetPreprocessingPipeline is None:
+            log.error("No configuration parameters found for PeaknetPreprocessingPipeline")
             sys.exit(1)
 
-        config = parameters.PreprocessingBatchPipeline
+        config = parameters.PeaknetPreprocessingPipeline
         self._batch_size: int = config.batch_size
 
         # Initialize padding utility

--- a/src/lclstreamer/frontend/processing_pipelines/preprocessing.py
+++ b/src/lclstreamer/frontend/processing_pipelines/preprocessing.py
@@ -1,0 +1,117 @@
+"""
+Preprocessing utilities for image data.
+
+This module contains utilities for preprocessing image data, including padding
+and channel dimension manipulation. The implementations are adapted from peaknet
+but use numpy arrays instead of PyTorch tensors to match the lclstreamer data format.
+"""
+
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ...protocols.backend import StrFloatIntNDArray
+
+
+class NumpyPad:
+    """
+    Pads numpy arrays to a specified target size.
+
+    This class handles padding of 2D numpy arrays (H, W) to target dimensions.
+    It supports different padding styles and uses zero-padding.
+
+    Args:
+        target_height: Target height after padding
+        target_width: Target width after padding
+        pad_style: Padding style - "center" or "bottom-right"
+    """
+
+    def __init__(
+        self,
+        target_height: int,
+        target_width: int,
+        pad_style: Literal["center", "bottom-right"] = "center"
+    ):
+        self.target_height = target_height
+        self.target_width = target_width
+        self.pad_style = pad_style
+
+    def calc_pad_width(self, img: NDArray) -> tuple[tuple[int, int], tuple[int, int]]:
+        """
+        Calculate padding widths for the given image.
+
+        Args:
+            img: Input image array with shape (H, W)
+
+        Returns:
+            Padding widths in format ((top, bottom), (left, right))
+        """
+        H_img, W_img = img.shape
+
+        dH_padded = max(self.target_height - H_img, 0)
+        dW_padded = max(self.target_width - W_img, 0)
+
+        if self.pad_style == "center":
+            pad_width = (
+                (dH_padded // 2, dH_padded - dH_padded // 2),  # (top, bottom)
+                (dW_padded // 2, dW_padded - dW_padded // 2),  # (left, right)
+            )
+        elif self.pad_style == "bottom-right":
+            pad_width = (
+                (0, dH_padded),  # (top, bottom)
+                (0, dW_padded),  # (left, right)
+            )
+        else:
+            raise ValueError(f"Invalid pad_style '{self.pad_style}'. Use 'center' or 'bottom-right'.")
+
+        return pad_width
+
+    def __call__(self, img: NDArray) -> NDArray:
+        """
+        Apply padding to the input image.
+
+        Args:
+            img: Input image array with shape (H, W)
+
+        Returns:
+            Padded image array with shape (target_height, target_width)
+        """
+        pad_width = self.calc_pad_width(img)
+        img_padded = np.pad(img, pad_width, mode='constant', constant_values=0)
+
+        return img_padded
+
+
+def add_channel_dimension(
+    batch_array: StrFloatIntNDArray,
+    num_channels: int = 1
+) -> StrFloatIntNDArray:
+    """
+    Add channel dimension to batched array.
+
+    Converts (B, H, W) format to (B, C, H, W) format by adding a channel dimension.
+
+    Args:
+        batch_array: Input batched array with shape (B, H, W)
+        num_channels: Number of channels to add (default: 1)
+
+    Returns:
+        Array with added channel dimension (B, C, H, W)
+
+    Raises:
+        ValueError: If input array doesn't have expected 3D shape
+    """
+    if len(batch_array.shape) != 3:
+        raise ValueError(
+            f"Expected 3D input array (B, H, W), got shape {batch_array.shape}"
+        )
+
+    # Add channel dimension at position 1: (B, H, W) -> (B, 1, H, W)
+    result = np.expand_dims(batch_array, axis=1)
+
+    # If num_channels > 1, repeat along channel dimension
+    if num_channels > 1:
+        result = np.repeat(result, num_channels, axis=1)
+
+    return result

--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -39,6 +39,15 @@ class BatchProcessingPipelineParameters(CustomBaseModel):
     batch_size: int
 
 
+class PreprocessingBatchPipelineParameters(CustomBaseModel):
+    batch_size: int
+    target_height: int
+    target_width: int
+    pad_style: Literal["center", "bottom-right"] = "center"
+    add_channel_dim: bool = True
+    num_channels: int = 1
+
+
 class BinaryDataStreamingDataHandlerParameters(CustomBaseModel):
     urls: list[str]
     role: Literal["server", "client"] = "server"
@@ -75,6 +84,7 @@ class EventSourceParameters(CustomBaseModel):
 
 class ProcessingPipelineParameters(CustomBaseModel):
     BatchProcessingPipeline: BatchProcessingPipelineParameters | None = None
+    PreprocessingBatchPipeline: PreprocessingBatchPipelineParameters | None = None
 
 
 class DataSerializerParameters(CustomBaseModel):

--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -39,7 +39,7 @@ class BatchProcessingPipelineParameters(CustomBaseModel):
     batch_size: int
 
 
-class PreprocessingBatchPipelineParameters(CustomBaseModel):
+class PeaknetPreprocessingPipelineParameters(CustomBaseModel):
     batch_size: int
     target_height: int
     target_width: int
@@ -84,7 +84,7 @@ class EventSourceParameters(CustomBaseModel):
 
 class ProcessingPipelineParameters(CustomBaseModel):
     BatchProcessingPipeline: BatchProcessingPipelineParameters | None = None
-    PreprocessingBatchPipeline: PreprocessingBatchPipelineParameters | None = None
+    PeaknetPreprocessingPipeline: PeaknetPreprocessingPipelineParameters | None = None
 
 
 class DataSerializerParameters(CustomBaseModel):


### PR DESCRIPTION
## Summary
  Adds configurable image preprocessing to the producer for downstream ML models requiring specific data formats.

  ## Changes
  - **New PreprocessingBatchPipeline**: Combines image padding and channel dimension addition with existing batching
  - **Configurable padding**: Target size and style (center/bottom-right) via YAML config
  - **Channel dimension support**: Converts (B,H,W) → (B,C,H,W) format
  - **Updated example config**: Demonstrates 1920x1920 padding with single channel

  ## Processing Order
  1. Pad individual images to target size
  2. Batch padded images
  3. Add channel dimension to batched data

  ## Configuration Example
  ```yaml
  processing_pipeline:
      PreprocessingBatchPipeline:
          batch_size: 16
          target_height: 1920
          target_width: 1920
          pad_style: center
          add_channel_dim: true
          num_channels: 1

  Testing

  Verified output shape changes from (16, 1691, 1691) to (16, 1, 1920, 1920) with distributed streaming setup.