### PR TITLE
demo/amsc-peaknet-2026: timestamp fixes for NERSC PeakNet demo

### DIFF
--- a/examples/lclstreamer-psana1-to-sdfada-with-preprocessing.yaml
+++ b/examples/lclstreamer-psana1-to-sdfada-with-preprocessing.yaml
@@ -29,7 +29,6 @@ processing_pipeline:
     target_width: 2048
     pad_style: center
     add_channel_dim: true
-    num_channels: 1
 
 data_serializer:
     type: HDF5BinarySerializer

--- a/examples/lclstreamer-psana1-to-sdfada.yaml
+++ b/examples/lclstreamer-psana1-to-sdfada.yaml
@@ -24,7 +24,6 @@ processing_pipeline:
     target_width: 1920
     pad_style: center
     add_channel_dim: true
-    num_channels: 1
 
 data_serializer:
     type: HDF5BinarySerializer

--- a/examples/lclstreamer-random-to-sdfada-numpy.yaml
+++ b/examples/lclstreamer-random-to-sdfada-numpy.yaml
@@ -1,0 +1,39 @@
+source_identifier: random_data_stream
+skip_incomplete_events: false
+
+event_source:
+    type: InternalEventSource
+    number_of_events_to_generate: 1200
+
+data_sources:
+    timestamp:
+        type: GenericRandomTimestamp
+
+    detector_data:
+        type: GenericRandomNumpyArray
+        array_shape: "1920,1920"
+        array_dtype: float32
+
+    photon_wavelength:
+        type: GenericRandomWavelength
+
+processing_pipeline:
+    type: PeaknetPreprocessingPipeline
+    batch_size: 8
+    target_height: 1920
+    target_width: 1920
+    pad_style: center
+    add_channel_dim: true
+
+data_serializer:
+    type: NumpyBinarySerializer
+    use_compression: true
+
+data_handlers:
+    - type: BinaryDataStreamingDataHandler
+      urls:
+          - "tcp://sdfada014:12321"
+          - "tcp://sdfada014:12322"
+      role: client
+      library: zmq
+      socket_type: push

--- a/src/lclstreamer/data_serializers/files/numpy.py
+++ b/src/lclstreamer/data_serializers/files/numpy.py
@@ -1,0 +1,65 @@
+from collections.abc import Iterator
+from io import BytesIO
+
+import numpy
+
+from ...models.parameters import (
+    NumpyBinarySerializerParameters,
+)
+from ...utils.logging import log_error_and_exit
+from ...utils.protocols import DataSerializerProtocol
+from ...utils.typing import StrFloatIntNDArray
+
+
+class NumpyBinarySerializer(DataSerializerProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(self, parameters: NumpyBinarySerializerParameters) -> None:
+        """
+        Initializes a Numpy data serializer
+
+        This serializer turns a dictionary of numpy arrays into a binary blob with the
+        internal structure of a .npz file (numpy's native format), according to the
+        preferences specified by the configuration parameters.
+
+        Arguments:
+
+            parameters: The configuration parameters
+        """
+        if parameters.type != "NumpyBinarySerializer":
+            log_error_and_exit(
+                "Data serializer parameters do not match the expected type"
+            )
+
+        self._use_compression: bool = parameters.use_compression
+
+    def __call__(
+        self, stream: Iterator[dict[str, StrFloatIntNDArray | None]]
+    ) -> Iterator[bytes]:
+        """
+        Serializes a stream of event data dictionaries to .npz binary blobs
+
+        Arguments:
+
+            stream: An iterator of event data dictionaries
+
+        Yields:
+
+            byte_block: A binary blob (a bytes object) with .npz internal structure
+        """
+        data: dict[str, StrFloatIntNDArray | None]
+        for data in stream:
+            # Filter out None values before serialization
+            arrays: dict[str, StrFloatIntNDArray] = {
+                k: v for k, v in data.items() if v is not None
+            }
+
+            with BytesIO() as byte_block:
+                if self._use_compression:
+                    numpy.savez_compressed(byte_block, **arrays)
+                else:
+                    numpy.savez(byte_block, **arrays)
+
+                yield byte_block.getvalue()

--- a/src/lclstreamer/data_serializers/setup.py
+++ b/src/lclstreamer/data_serializers/setup.py
@@ -6,6 +6,7 @@ from ..utils.logging import log_error_and_exit
 from ..utils.protocols import DataSerializerProtocol
 from .dectris.simplon import SimplonBinarySerializer as SimplonBinarySerializer
 from .files.hdf5 import HDF5BinarySerializer as HDF5BinarySerializer
+from .files.numpy import NumpyBinarySerializer as NumpyBinarySerializer
 
 
 def initialize_data_serializer(

--- a/src/lclstreamer/event_data_sources/generic/data_sources.py
+++ b/src/lclstreamer/event_data_sources/generic/data_sources.py
@@ -193,6 +193,94 @@ class GenericRandomNumpyArray(DataSourceProtocol):
             )
 
 
+class GenericRandomTimestamp(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        additional_info: dict[str, Any],
+    ):
+        """
+        Initializes a Generic Random Timestamp Data Source
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+
+            additional_info: Additional information (unused)
+        """
+        del name
+        del parameters
+        del additional_info
+
+    def get_data(self, event: Any) -> NDArray[numpy.float64]:
+        """
+        Retrieves a random timestamp value (Unix epoch time in seconds)
+
+        Arguments:
+
+            event: An event object (unused)
+
+        Returns:
+
+            timestamp: A 0-dimensional numpy float64 array containing a random
+                timestamp in the range ~2020-2023
+        """
+        del event
+        random_timestamp: float = numpy.random.uniform(1600000000, 1700000000)
+        return numpy.array(random_timestamp, dtype=numpy.float64)
+
+
+class GenericRandomWavelength(DataSourceProtocol):
+    """
+    See documentation of the `__init__` function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: DataSourceParameters,
+        additional_info: dict[str, Any],
+    ):
+        """
+        Initializes a Generic Random Wavelength Data Source
+
+        Arguments:
+
+            name: An identifier for the data source
+
+            parameters: The configuration parameters
+
+            additional_info: Additional information (unused)
+        """
+        del name
+        del parameters
+        del additional_info
+
+    def get_data(self, event: Any) -> NDArray[numpy.float64]:
+        """
+        Retrieves a random wavelength value in the typical X-ray range
+
+        Arguments:
+
+            event: An event object (unused)
+
+        Returns:
+
+            wavelength: A 0-dimensional numpy float64 array containing a random
+                wavelength value between 0.1 and 10.0 Angstroms
+        """
+        del event
+        random_wavelength: float = numpy.random.uniform(0.1, 10.0)
+        return numpy.array(random_wavelength, dtype=numpy.float64)
+
+
 class SourceIdentifier(DataSourceProtocol):
     """
     See documentation of the `__init__` function.

--- a/src/lclstreamer/event_data_sources/generic/event_sources.py
+++ b/src/lclstreamer/event_data_sources/generic/event_sources.py
@@ -18,6 +18,12 @@ from .data_sources import (
     GenericRandomNumpyArray as GenericRandomNumpyArray,
 )
 from .data_sources import (
+    GenericRandomTimestamp as GenericRandomTimestamp,
+)
+from .data_sources import (
+    GenericRandomWavelength as GenericRandomWavelength,
+)
+from .data_sources import (
     IntValue as IntValue,
 )
 

--- a/src/lclstreamer/event_data_sources/psana1/data_sources.py
+++ b/src/lclstreamer/event_data_sources/psana1/data_sources.py
@@ -33,9 +33,12 @@ class Psana1Timestamp(DataSourceProtocol):
         del parameters
         del additional_info
 
-    def get_data(self, event: Any) -> NDArray[numpy.float64]:
+    def get_data(self, event: Any) -> NDArray[numpy.uint64]:
         """
         Retrieves timestamp information from a psana1 event
+
+        Encodes the timestamp as a uint64 matching psana2's native format:
+        upper 32 bits = seconds, lower 32 bits = nanoseconds.
 
         Arguments:
 
@@ -43,15 +46,18 @@ class Psana1Timestamp(DataSourceProtocol):
 
         Returns:
 
-            timestamp: a 1D numpy array (of type float64) containing the timestamp
-            information
+            timestamp: a numpy scalar (uint64) with seconds in upper 32 bits
+            and nanoseconds in lower 32 bits
         """
         psana_event_id: Any = event.get(
             EventId  # pyright: ignore[reportAttributeAccessIssue]
         )
         timestamp_epoch_format: Any = psana_event_id.time()
+        seconds = int(timestamp_epoch_format[0])
+        nanoseconds = int(timestamp_epoch_format[1])
         return numpy.array(
-            str(timestamp_epoch_format[0]) + "." + str(timestamp_epoch_format[1])
+            (seconds << 32) | nanoseconds,
+            dtype=numpy.uint64,
         )
 
 

--- a/src/lclstreamer/event_data_sources/psana2/data_sources.py
+++ b/src/lclstreamer/event_data_sources/psana2/data_sources.py
@@ -30,9 +30,12 @@ class Psana2Timestamp(DataSourceProtocol):
         """
         pass
 
-    def get_data(self, event: Any) -> NDArray[numpy.float64]:
+    def get_data(self, event: Any) -> NDArray[numpy.uint64]:
         """
-        Retrieves timestamp information from a psana2 event
+        Retrieves timestamp information from a psana2 event.
+
+        The psana2 event.timestamp is natively a uint64 with seconds in the
+        upper 32 bits and nanoseconds in the lower 32 bits.
 
         Arguments:
 
@@ -40,10 +43,10 @@ class Psana2Timestamp(DataSourceProtocol):
 
         Returns:
 
-            timestamp: a 1D numpy array (of type float64) containing the timestamp
-            information
+            timestamp: a numpy scalar (uint64) with seconds in upper 32 bits
+            and nanoseconds in lower 32 bits
         """
-        return numpy.array(event.timestamp, dtype=numpy.float64)
+        return numpy.array(event.timestamp, dtype=numpy.uint64)
 
 
 class Psana2DetectorInterface(DataSourceProtocol):

--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -119,9 +119,9 @@ class PeaknetPreprocessingPipelineParameters(_CustomBaseModel):
     """
     Configuration parameters for the PeakNet Preprocessing Pipeline
 
-    This pipeline pads detector images to a uniform size, accumulates them
-    into batches, and optionally adds a channel dimension, preparing the data
-    for inference with the PeakNet model
+    This pipeline adds a channel dimension, pads detector images to a uniform
+    size, optionally applies instance normalization, accumulates them into
+    batches, and optionally merges batch and channel dimensions
 
     Attributes:
 
@@ -138,11 +138,23 @@ class PeaknetPreprocessingPipelineParameters(_CustomBaseModel):
             (padding added only to the bottom and right edges)
             Defaults to ``"center"``
 
-        add_channel_dim: Whether to insert a channel dimension after batching,
-            converting (B, H, W) arrays to (B, C, H, W). Defaults to ``True``
+        add_channel_dim: Whether to insert a channel dimension before padding,
+            converting (H, W) images to (1, H, W). Defaults to ``True``
 
-        num_channels: Number of channels to produce when ``add_channel_dim``
-            is ``True``. Defaults to ``1``
+        merge_batch_and_channel: Whether to reshape (B, C, H, W) to
+            (B*C, 1, H, W) after batching. Defaults to ``False``
+
+        apply_normalization: Whether to apply instance normalization to each
+            image before batching. Defaults to ``False``
+
+        norm_eps: Small constant for numerical stability in normalization.
+            Defaults to ``1e-5``
+
+        norm_check_nan: Whether to check for NaN values after normalization.
+            Defaults to ``True``
+
+        norm_scale_variance: Whether to scale by standard deviation during
+            normalization. Defaults to ``True``
     """
 
     type: Literal["PeaknetPreprocessingPipeline"]
@@ -151,7 +163,11 @@ class PeaknetPreprocessingPipelineParameters(_CustomBaseModel):
     target_width: int
     pad_style: Literal["center", "bottom-right"] = "center"
     add_channel_dim: bool = True
-    num_channels: int = 1
+    merge_batch_and_channel: bool = False
+    apply_normalization: bool = False
+    norm_eps: float = 1e-5
+    norm_check_nan: bool = True
+    norm_scale_variance: bool = True
 
 
 ProcessingPipelineParameters = Annotated[
@@ -238,8 +254,31 @@ class HDF5BinarySerializerParameters(_CustomBaseModel):
     fields: Dict[str, str]
 
 
+class NumpyBinarySerializerParameters(_CustomBaseModel):
+    """
+    Configuration parameters for the Numpy binary serializer
+
+    This serializer encodes a batch of event data arrays into an in-memory
+    .npz file (numpy's native format). Optional gzip compression can be applied
+
+    Attributes:
+
+        type: Discriminator field, must be ``"NumpyBinarySerializer"``
+
+        use_compression: Whether to use gzip compression when saving the .npz
+            file. Defaults to ``True``
+    """
+
+    type: Literal["NumpyBinarySerializer"]
+    use_compression: bool = True
+
+
 DataSerializerParameters = Annotated[
-    Union[HDF5BinarySerializerParameters, SimplonBinarySerializerParameters],
+    Union[
+        HDF5BinarySerializerParameters,
+        NumpyBinarySerializerParameters,
+        SimplonBinarySerializerParameters,
+    ],
     Field(discriminator="type"),
 ]
 

--- a/src/lclstreamer/processing_pipelines/crystallography/peaknet.py
+++ b/src/lclstreamer/processing_pipelines/crystallography/peaknet.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import numpy
 from numpy.typing import NDArray
@@ -27,8 +27,9 @@ class _NumpyPad:
         """
         Initializes a numpy array padder to a specified target size
 
-        This class handles padding of 2D numpy arrays (H, W) to target dimensions
-        It supports different padding styles and uses zero-padding
+        This class handles padding of 3D numpy arrays (C, H, W) to target dimensions.
+        Only the spatial dimensions (H, W) are padded; the channel dimension is
+        unchanged. It supports different padding styles and uses zero-padding
 
         Arguments:
 
@@ -44,30 +45,32 @@ class _NumpyPad:
 
     def calc_pad_width(
         self, img: NDArray[numpy.floating[Any]]
-    ) -> tuple[tuple[int, int], tuple[int, int]]:
+    ) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int]]:
         """
         Calculates padding widths for the given image
 
         Arguments:
 
-            img: Input image array with shape (H, W)
+            img: Input image array with shape (C, H, W)
 
         Returns:
 
-            pad_width: Padding widths in format ((top, bottom), (left, right))
+            pad_width: Padding widths in format ((0, 0), (top, bottom), (left, right))
         """
-        H_img, W_img = img.shape
+        C_img, H_img, W_img = img.shape
 
         dH_padded = max(self.target_height - H_img, 0)
         dW_padded = max(self.target_width - W_img, 0)
 
         if self.pad_style == "center":
             pad_width = (
+                (0, 0),  # No padding on channel dimension
                 (dH_padded // 2, dH_padded - dH_padded // 2),  # (top, bottom)
                 (dW_padded // 2, dW_padded - dW_padded // 2),  # (left, right)
             )
         elif self.pad_style == "bottom-right":
             pad_width = (
+                (0, 0),  # No padding on channel dimension
                 (0, dH_padded),  # (top, bottom)
                 (0, dW_padded),  # (left, right)
             )
@@ -87,11 +90,11 @@ class _NumpyPad:
 
         Arguments:
 
-            img: Input image array with shape (H, W)
+            img: Input image array with shape (C, H, W)
 
         Returns:
 
-            img_padded: Padded image array with shape (target_height, target_width)
+            img_padded: Padded image array with shape (C, target_height, target_width)
         """
         pad_width = self.calc_pad_width(img)
         img_padded: NDArray[numpy.floating[Any]] = numpy.pad(
@@ -101,48 +104,98 @@ class _NumpyPad:
         return img_padded
 
 
-def _add_channel_dimension(
-    array: StrFloatIntNDArray, num_channels: int = 1
-) -> StrFloatIntNDArray:
+class _NumpyInstanceNorm:
     """
-    Adds a channel dimension to a batched array
+    See documentation of the `__init__` function
+    """
 
-    Converts (B, H, W) format to (B, C, H, W) format by inserting a channel
-    dimension at axis 1. If `num_channels` is greater than 1, the new axis is
-    tiled by repeating the data along that dimension
+    def __init__(
+        self,
+        eps: float = 1e-5,
+        check_nan: bool = True,
+        scale_variance: bool = True,
+    ):
+        """
+        Initializes an instance normalizer for numpy arrays
+
+        Normalizes each sample independently across all dimensions. Adapted from
+        peaknet's InstanceNorm for numpy compatibility
+
+        Arguments:
+
+            eps: Small constant for numerical stability in variance computation
+
+            check_nan: Whether to check for NaN values in normalized output
+
+            scale_variance: Whether to scale by standard deviation (if False,
+                only centers the data)
+        """
+        self.eps = eps
+        self.check_nan = check_nan
+        self.scale_variance = scale_variance
+
+    def __call__(
+        self, img: NDArray[numpy.floating[Any]]
+    ) -> NDArray[numpy.floating[Any]]:
+        """
+        Applies instance normalization to a single image
+
+        Arguments:
+
+            img: Input image array with shape (C, H, W)
+
+        Returns:
+
+            img_norm: Normalized image array with same shape (C, H, W)
+
+        Raises:
+
+            ValueError: If NaN values are detected in output and check_nan is True
+        """
+        mean = numpy.mean(img)
+        img_norm: NDArray[numpy.floating[Any]] = img - mean
+
+        if self.scale_variance:
+            variance = numpy.var(img, ddof=0)
+            img_norm = img_norm / numpy.sqrt(variance + self.eps)
+
+        if self.check_nan and numpy.isnan(img_norm).any():
+            raise ValueError("NaN values detected in normalized output")
+
+        return img_norm
+
+
+def _add_channel_dimension(image_array: StrFloatIntNDArray) -> StrFloatIntNDArray:
+    """
+    Adds a channel dimension to an individual image
+
+    Converts (H, W) format to (1, H, W) format by adding a channel dimension
 
     Arguments:
 
-        array: Input array with shape (B, H, W)
-
-        num_channels: Number of channels to produce (default: 1)
+        image_array: Input image array with shape (H, W)
 
     Returns:
 
-        result: Array with an added channel dimension of shape (B, C, H, W)
+        result: Array with added channel dimension (1, H, W)
 
     Raises:
 
-        ValueError: If the input array does not have exactly 3 dimensions
+        ValueError: If input array doesn't have expected 2D shape
     """
-    if len(array.shape) != 3:
-        raise ValueError(f"Expected 3D input array (B, H, W), got shape {array.shape}")
+    if len(image_array.shape) != 2:
+        raise ValueError(
+            f"Expected 2D input array (H, W), got shape {image_array.shape}"
+        )
 
-    # Add channel dimension at position 1: (B, H, W) -> (B, 1, H, W)
-    result: StrFloatIntNDArray = numpy.expand_dims(array, axis=1)
-
-    # If num_channels > 1, repeat along channel dimension
-    if num_channels > 1:
-        result = numpy.repeat(result, num_channels, axis=1)
-
+    result: StrFloatIntNDArray = numpy.expand_dims(image_array, axis=0)
     return result
 
 
 def _is_image_data(data_key: str, data_value: StrFloatIntNDArray | None) -> bool:
     # Determines if a data entry represents image data that should be preprocessed
-    # Heuristic: 2D arrays are likely images
-    # You may want to refine this logic based on your specific data keys
-    return isinstance(data_value, numpy.ndarray) and len(data_value.shape) == 2
+    # Heuristic: 2D arrays (H, W) or 3D arrays (C, H, W) are likely images
+    return isinstance(data_value, numpy.ndarray) and len(data_value.shape) in [2, 3]
 
 
 class PeaknetPreprocessingPipeline(ProcessingPipelineProtocol):
@@ -157,9 +210,13 @@ class PeaknetPreprocessingPipeline(ProcessingPipelineProtocol):
         This pipeline applies image preprocessing and batching in the following
         order:
 
-        1. Pad individual images to the configured target size (before batching)
-        2. Accumulate padded images into batches of `batch_size`
-        3. Add a channel dimension to the batched image data (after batching)
+        1. Add channel dimension to individual images if needed: (H, W) -> (1, H, W)
+        2. Pad individual images to the configured target size: (C, H, W) ->
+           (C, target_height, target_width)
+        3. Apply instance normalization if enabled (before batching)
+        4. Accumulate preprocessed images into batches of ``batch_size``
+        5. Optionally merge batch and channel dimensions: (B, C, H, W) ->
+           (B*C, 1, H, W)
 
         Non-image data (timestamps, scalars, etc.) is passed through unchanged
         at every stage
@@ -185,7 +242,75 @@ class PeaknetPreprocessingPipeline(ProcessingPipelineProtocol):
 
         # Channel dimension settings
         self._add_channel_dim: bool = parameters.add_channel_dim
-        self._num_channels: int = parameters.num_channels
+        self._merge_batch_and_channel: bool = parameters.merge_batch_and_channel
+
+        # Normalization settings
+        self._apply_normalization: bool = parameters.apply_normalization
+        if self._apply_normalization:
+            self._normalizer: _NumpyInstanceNorm = _NumpyInstanceNorm(
+                eps=parameters.norm_eps,
+                check_nan=parameters.norm_check_nan,
+                scale_variance=parameters.norm_scale_variance,
+            )
+
+    def _apply_batch_channel_merge(
+        self, batched_data: dict[str, StrFloatIntNDArray | None]
+    ) -> None:
+        """
+        Reshapes image data from (B, C, H, W) to (B*C, 1, H, W) if enabled
+
+        Arguments:
+
+            batched_data: Dictionary of batched arrays to modify in-place
+        """
+        if not self._merge_batch_and_channel:
+            return
+
+        data_key: str
+        data_value: StrFloatIntNDArray | None
+        for data_key, data_value in batched_data.items():
+            if data_value is None or data_key.endswith("_original_shape"):
+                continue
+
+            if len(data_value.shape) == 4:
+                B, C, H, W = data_value.shape
+                batched_data[data_key] = data_value.reshape(B * C, 1, H, W)
+
+    def _finalize_batch(
+        self,
+        data_storage: DataStorage,
+        original_shapes: dict[str, tuple[int, int, int]],
+    ) -> dict[str, StrFloatIntNDArray | None]:
+        """
+        Retrieves stored data, adds shape metadata, and applies batch-channel merge
+
+        Arguments:
+
+            data_storage: The data storage containing accumulated events
+
+            original_shapes: Dictionary mapping data keys to their original
+                (C, H, W) shapes before preprocessing
+
+        Returns:
+
+            batched_data: The finalized batch dictionary
+        """
+        batched_data: dict[str, StrFloatIntNDArray | None] = (
+            data_storage.retrieve_stored_data()
+        )
+
+        # Add original shape metadata for each image data key
+        data_key: str
+        for data_key, (orig_c, orig_h, orig_w) in original_shapes.items():
+            if batched_data.get(data_key) is not None:
+                batch_size: int = batched_data[data_key].shape[0]  # type: ignore[union-attr]
+                batched_data[f"{data_key}_original_shape"] = numpy.array(
+                    [batch_size, orig_c, orig_h, orig_w], dtype=numpy.int32
+                )
+
+        self._apply_batch_channel_merge(batched_data)
+
+        return batched_data
 
     def __call__(
         self, stream: Iterator[dict[str, StrFloatIntNDArray | None]]
@@ -199,71 +324,60 @@ class PeaknetPreprocessingPipeline(ProcessingPipelineProtocol):
 
         Arguments:
 
-            stream: A dictionary storing event data
+            stream: An iterator of event data dictionaries
 
         Yields:
 
             batch: A dictionary of processed and batched events
         """
         data_storage: DataStorage = DataStorage()
+        original_shapes: dict[str, tuple[int, int, int]] = {}
 
         data: dict[str, StrFloatIntNDArray | None]
         for data in stream:
-            # Apply preprocessing to image data before adding to batch
             preprocessed_data: dict[str, StrFloatIntNDArray | None] = {}
 
             data_key: str
             data_value: StrFloatIntNDArray | None
             for data_key, data_value in data.items():
                 if data_value is not None and _is_image_data(data_key, data_value):
-                    # Apply padding to image data
-                    preprocessed_data[data_key] = self._padder(
-                        cast(NDArray[numpy.floating[Any]], data_value)
-                    )
+                    # Capture original shape before any preprocessing (first image only)
+                    if data_key not in original_shapes:
+                        if len(data_value.shape) == 2:
+                            original_shapes[data_key] = (
+                                1,
+                                data_value.shape[0],
+                                data_value.shape[1],
+                            )
+                        elif len(data_value.shape) == 3:
+                            original_shapes[data_key] = (
+                                data_value.shape[0],
+                                data_value.shape[1],
+                                data_value.shape[2],
+                            )
+
+                    # Add channel dimension if needed: (H, W) -> (1, H, W)
+                    if self._add_channel_dim and len(data_value.shape) == 2:
+                        data_value = _add_channel_dimension(data_value)
+
+                    # Apply padding: (C, H, W) -> (C, target_height, target_width)
+                    data_value = self._padder(data_value)
+
+                    # Apply normalization before batching (if enabled)
+                    if self._apply_normalization:
+                        data_value = self._normalizer(data_value)
+
+                    preprocessed_data[data_key] = data_value
                 else:
-                    # Pass through non-image data unchanged
                     preprocessed_data[data_key] = data_value
 
             data_storage.add_data(data=preprocessed_data)
 
             if len(data_storage) >= self._batch_size:
-                batched_data: dict[str, StrFloatIntNDArray | None] = (
-                    data_storage.retrieve_stored_data()
-                )
-
-                # Add channel dimension to image data after batching
-                if self._add_channel_dim:
-                    final_data: dict[str, StrFloatIntNDArray | None] = {}
-
-                    for data_key, data_value in batched_data.items():
-                        if data_value is not None and len(data_value.shape) == 3:
-                            # This is batched image data (B, H, W) -> add channel (B, C, H, W)
-                            final_data[data_key] = _add_channel_dimension(
-                                data_value, self._num_channels
-                            )
-                        else:
-                            # Pass through non-image data
-                            final_data[data_key] = data_value
-                    yield final_data
-                else:
-                    yield batched_data
-
+                yield self._finalize_batch(data_storage, original_shapes)
                 data_storage.reset_data_storage()
+                original_shapes = {}
 
         # Handle remaining data
         if len(data_storage) > 0:
-            batched_data = data_storage.retrieve_stored_data()
-
-            # Add channel dimension to remaining data if configured
-            if self._add_channel_dim:
-                final_data = {}
-                for data_key, data_value in batched_data.items():
-                    if data_value is not None and len(data_value.shape) == 3:
-                        final_data[data_key] = _add_channel_dimension(
-                            data_value, self._num_channels
-                        )
-                    else:
-                        final_data[data_key] = data_value
-                yield final_data
-            else:
-                yield batched_data
+            yield self._finalize_batch(data_storage, original_shapes)


### PR DESCRIPTION
## Summary

- Cherry-picks timestamp dtype fixes from `fix/timestamp-dtype` onto current `main`
- Adds numpy binary serializer support needed for the streaming pipeline

## Commits

- Re-apply numpy-serializer features onto refactored main
- Fix Psana1Timestamp to use uint64 matching psana2 format
- Fix Psana2Timestamp to use uint64 matching psana1 format

## Context

These fixes are needed for the NERSC PeakNet streaming demo (AMSC project). The `fix/timestamp-dtype` branch had diverged from `main`, so this branch provides a clean rebase of the functional changes onto current `main`.

Closes #31

## Test plan

- [x] Validated on NERSC Perlmutter with synthetic data (SLURM job 51347958, 142/150 batches processed)
- [x] lclstreamer installs and runs with `InternalEventSource` (no psana) on Perlmutter
- [ ] Timestamp uint64 fix should be verified with real psana1/psana2 data