### PR TITLE
Fix off-by-one in DataStorage._count on first add_data call

### DIFF
--- a/src/lclstreamer/processing_pipelines/common/data_storage.py
+++ b/src/lclstreamer/processing_pipelines/common/data_storage.py
@@ -149,7 +149,7 @@ class DataStorage:
                                 "with which this label was originally initialized"
                             )
                         data_container.data.append(data_value)
-            self._count += 1
+        self._count += 1
 
     def retrieve_stored_data(self) -> dict[str, StrFloatIntNDArray | None]:
         """

--- a/tests/test_data_storage.py
+++ b/tests/test_data_storage.py
@@ -1,0 +1,46 @@
+import numpy
+
+from lclstreamer.processing_pipelines.common.data_storage import DataStorage
+
+
+def test_len_is_zero_initially():
+    storage = DataStorage()
+    assert len(storage) == 0
+
+
+def test_len_is_one_after_first_add():
+    storage = DataStorage()
+    storage.add_data({"x": numpy.zeros((4,), dtype=numpy.float32)})
+    assert len(storage) == 1
+
+
+def test_len_counts_every_add():
+    storage = DataStorage()
+    for _ in range(5):
+        storage.add_data({"x": numpy.zeros((4,), dtype=numpy.float32)})
+    assert len(storage) == 5
+
+
+def test_reset_zeroes_count_and_count_resumes_from_one():
+    storage = DataStorage()
+    for _ in range(3):
+        storage.add_data({"x": numpy.zeros((4,), dtype=numpy.float32)})
+
+    storage.reset_data_storage()
+    assert len(storage) == 0
+
+    storage.add_data({"x": numpy.zeros((4,), dtype=numpy.float32)})
+    assert len(storage) == 1
+
+
+def test_len_counts_dict_typed_events():
+    storage = DataStorage()
+    event = {
+        "detector": {
+            "image": numpy.zeros((2, 2), dtype=numpy.float32),
+            "mask": numpy.zeros((2, 2), dtype=numpy.float32),
+        }
+    }
+    storage.add_data(event)
+    storage.add_data(event)
+    assert len(storage) == 2


### PR DESCRIPTION
## Summary

`DataStorage._count` was incremented only in the `else` branch of `add_data`, so the first call left it at 0 while per-source containers held 1 element each. The yield trigger (`len(data_storage) >= batch_size`) fired one event late → first batch emitted as `batch_size + 1`. PeakNet Ray actor hard-asserts batch size and crashed with `ValueError: Batch size mismatch`, producing 0 events written.

Fix: dedent `self._count += 1` so it runs on every call.

## Validation

E2E `sbatch run-demo.sbatch` (job 25925796): 0 mismatches, all batches B=8, 41+ batches processed (328+ events), 5 CXI files (~1.2 GB). Reference run on `dbc692d` had 4 mismatches and 0 events.

Independent of #35; bug exists on `dbc692d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)