### PR TITLE
Add GitHub Actions workflow for DataStorage regression test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-data-storage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.54.1
+          environments: psana1
+          cache: true
+      - run: pixi run -e psana1 pytest tests/test_data_storage.py -v


### PR DESCRIPTION
Adds `.github/workflows/test.yml` — runs `tests/test_data_storage.py` via `prefix-dev/setup-pixi` on the `psana1` env (`pytest` isn't in the default pixi deps).

Originally a commit on #36, extracted so #36 stays minimal.

Stacked on `fix/data-storage-count-off-by-one` so the workflow has the test file in its merge base. Auto-retargets to `main` after #36 lands.

Two known reds:
- Workflow trigger is `branches: [main]`, so it won't fire on this PR while base is the fix branch. First real run = post-rebase.
- `pixi install --locked` fails on `main` today — `pixi.lock` is out of sync with `pyproject.toml` (pre-existing). Workflow stays red until that's resolved.

Merge order: #36 → regenerate `pixi.lock` on `main` → this.
