### PR TITLE
Added new network parameters for performance

### DIFF
--- a/examples/lclstreamer-internal.yaml
+++ b/examples/lclstreamer-internal.yaml
@@ -38,6 +38,8 @@ data_handlers:
     - type: BinaryDataStreamingDataHandler
       urls:
           - "tcp://127.0.0.1:12321"
+      distribute: False
+      buffer: 0
       role: client
       library: zmq
       socket_type: push

--- a/examples/lclstreamer-psana1-simplon.yml
+++ b/examples/lclstreamer-psana1-simplon.yml
@@ -69,6 +69,8 @@ data_handlers:
     BinaryDataStreamingDataHandler:
         urls:
             - "tcp://134.79.23.43:5000" #127.0.0.1:12321"
+        distribute: False
+        buffer: 0
         role: client
         library: zmq
         socket_type: push

--- a/examples/lclstreamer-psana1-to-sdfada-with-preprocessing.yaml
+++ b/examples/lclstreamer-psana1-to-sdfada-with-preprocessing.yaml
@@ -46,5 +46,7 @@ data_handlers:
       urls:
           - "tcp://sdfada001:12321"
       role: client
+      distribute: False
+      buffer: 0
       library: zmq
       socket_type: push

--- a/examples/lclstreamer-psana1-to-sdfada.yaml
+++ b/examples/lclstreamer-psana1-to-sdfada.yaml
@@ -39,6 +39,8 @@ data_handlers:
     - type: BinaryDataStreamingDataHandler
       urls:
           - "tcp://sdfada001:12321"
+      distribute: False
+      buffer: 0
       role: client
       library: zmq
       socket_type: push

--- a/examples/lclstreamer-psana2-mfx.yaml
+++ b/examples/lclstreamer-psana2-mfx.yaml
@@ -49,6 +49,8 @@ data_handlers:
     - type: BinaryDataStreamingDataHandler
       urls:
           - "tcp://127.0.0.1:12321"
+      distribute: False
+      buffer: 0
       role: client
       library: zmq
       socket_type: push

--- a/examples/lclstreamer-psana2-simplon.yml
+++ b/examples/lclstreamer-psana2-simplon.yml
@@ -65,6 +65,8 @@ data_handlers:
     - type: BinaryDataStreamingDataHandler
       urls:
           - "tcp://127.0.0.1:12321" #127.0.0.1:12321" #134.79.23.43:5000" #127.0.0.1:12321"
+      distribute: False
+      buffer: 0
       role: client
       library: zmq
       #library: zmq

--- a/examples/producer_raw.yaml
+++ b/examples/producer_raw.yaml
@@ -1,0 +1,77 @@
+# LCLStreamer Producer Configuration - Raw Data for OpenCL Pipeline
+#
+# Streams raw uint16 Jungfrau data for GPU-side calibration.
+# This reduces network bandwidth (33MB vs 67MB) and enables GPU calibration.
+#
+# IMPORTANT: Before starting this producer, save calibration constants using:
+#   python scripts/save_calibration.py --experiment EXPERIMENT --run RUN
+#
+# Performance:
+# - Data size: 33 MB (uint16) vs 67 MB (float32 assembled)
+# - Deserialize: ~15-20ms vs ~40ms
+# - GPU compute: ~10ms (calib+assembly+azint) vs ~3ms (azint only)
+
+# Source identifier
+source_identifier: exp=mfx101344525,run=123
+skip_incomplete_events: true
+
+# Event source configuration
+event_source:
+    type: Psana2EventSource
+    #type: InternalEventSource
+    #number_of_events_to_generate: 15000
+
+# Data sources - raw uint16 data only
+data_sources:
+    #timestamp:
+    #    type: Psana2Timestamp
+
+    jungfrau_raw:
+        type: Psana2DetectorInterface
+        psana_name: jungfrau
+        psana_fields: raw.raw      # Raw uint16 data (not calibrated)
+        dtype: uint16
+
+    #jungfrau_raw:
+    #    type: GenericRandomNumpyArray
+    #    array_dtype: int16
+    #    array_shape: 32,512,1024
+
+# Processing pipeline
+processing_pipeline:
+    type: BatchProcessingPipeline
+    batch_size: 1
+
+# Fast binary serializer - no compression for maximum speed
+data_serializer:
+    type: HDF5BinarySerializer
+    compression_level: 0
+    compression: gzip
+    #fields:
+    #    #timestamp: data/timestamp
+    #    jungfrau.raw.raw: data/jungfrau_raw
+    #    #jungfrau_raw: data/jungfrau_raw
+
+# Data handler - stream to GPU consumer
+data_handlers:
+  - type: BinaryDataStreamingDataHandler
+    urls:
+    #        - "tcp://sdfiana024:8088"
+    #        - "tcp://sdfampere010:8086"
+    #        - "tcp://sdfampere010:8087"
+    #        - "tcp://sdfampere011:8086"
+    #        - "tcp://sdfampere011:8087"
+    #        - "ipc:///tmp/sdfmilan"
+    #        - "tcp://sdfmilan243:8086"
+    #        - "tcp://sdfmilan244:8086"
+            - "tcp://sdfiana025:8087"
+            - "tcp://sdfiana023:8086"
+            - "tcp://sdfiana023:8087"
+            - "tcp://sdfiana025:8086"
+    #        - "tcp://134.79.23.43:5000"
+    #        - "tcp://sdfiana025:8087"
+    distribute: True  # True: round robin connect the ranks, False: all ranks connect to all urls (same data sent)
+    buffer: 67108864 # 64 * 1024 * 1024 (64MB), - Capped by OS max, leave it as 0 to use OS default
+    role: client
+    library: zmq
+    socket_type: push

--- a/src/lclstreamer/data_handlers/streaming/binary.py
+++ b/src/lclstreamer/data_handlers/streaming/binary.py
@@ -1,7 +1,10 @@
 import sys
 import time
 
-from zmq import LINGER, PUSH, SNDHWM, Context, Socket, ZMQError
+from zmq import LINGER, PUSH, SNDHWM, Context, Socket, ZMQError, SNDBUF
+
+from mpi4py import MPI
+import socket
 
 from ...models.parameters import (
     BinaryDataStreamingDataHandlerParameters,
@@ -64,12 +67,31 @@ class BinaryStreamingPushDataHandlerZmq:
         self.data_handler_parameters = data_handler_parameters
         self._context: Context[Socket[bytes]] = Context()
         self._socket: Socket[bytes] = self._context.socket(PUSH)
+        # Set buffer size
+        if data_handler_parameters.buffer > 0:
+            self._socket.setsockopt(SNDBUF, data_handler_parameters.buffer)
         # Set linger to 0 so socket closes immediately without waiting
         self._socket.setsockopt(LINGER, 0)
         # Queue 5 messages if there is no receiver
         self._socket.setsockopt(SNDHWM, 5)
+
+        urls: list [str]
+        if data_handler_parameters.distribute:
+            mpi_rank: int = MPI.COMM_WORLD.Get_rank()
+            url_length: int = len(data_handler_parameters.urls)
+            world_size: int = MPI.COMM_WORLD.Get_size()
+            if world_size < url_length:
+                # This should not be the case
+                urls = data_handler_parameters.urls[mpi_rank::world_size]
+            else:
+                urls = [data_handler_parameters.urls[mpi_rank % url_length]]
+            if mpi_rank == 0:
+                log.info(f"Expecting {url_length} machines for receiving...")
+            log.info(f"Rank: {mpi_rank} on {socket.gethostname()} -> {urls}")
+        else:
+            urls = data_handler_parameters.urls
         url: str
-        for url in data_handler_parameters.urls:
+        for url in urls:
             try:
                 if data_handler_parameters.role == "server":
                     self._socket.bind(url)
@@ -93,7 +115,7 @@ class BinaryStreamingPushDataHandlerZmq:
             data: A bytes object containing serialized event data
         """
         try:
-            self._socket.send(data)
+            self._socket.send(data, copy=False)
         except ZMQError as e:
             log.error("ZMQ Send failed: %s", e)
 

--- a/src/lclstreamer/data_handlers/streaming/binary.py
+++ b/src/lclstreamer/data_handlers/streaming/binary.py
@@ -115,7 +115,7 @@ class BinaryStreamingPushDataHandlerZmq:
             data: A bytes object containing serialized event data
         """
         try:
-            self._socket.send(data, copy=False)
+            self._socket.send(data)
         except ZMQError as e:
             log.error("ZMQ Send failed: %s", e)
 

--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -260,6 +260,10 @@ class BinaryDataStreamingDataHandlerParameters(_CustomBaseModel):
         urls: List of endpoint URLs to bind to (server mode) or connect to
             (client mode)
 
+        distribute: Boolean, if True: round robin connect the ranks, False: all ranks connect to all urls and send the same data
+
+        buffer: buffer size, if set to 0 the OS default is used
+
         role: Whether this node acts as the ZMQ ``"server"`` (binds) or
             ``"client"`` (connects). Defaults to ``"server"``
 
@@ -272,6 +276,8 @@ class BinaryDataStreamingDataHandlerParameters(_CustomBaseModel):
 
     type: Literal["BinaryDataStreamingDataHandler"]
     urls: List[str]
+    distribute: bool
+    buffer: int
     role: Literal["server", "client"] = "server"
     library: Literal["zmq"] = "zmq"
     socket_type: Literal["push"] = "push"


### PR DESCRIPTION
- Added possibility to distribute the stream to different locations (e.g. using multiple caches).

- Added 2 new parameters for network settings: 
     1. distribute  - when True stream is distributed among ranks, when False, the same data is sent to all urls
     2. possibility to send buffer size (if set to 0, OS default is used)
 
- Added copy=False to send (not a major improvement according to my tests, but I would like to test it with the nersc tests before removing)