### PR TITLE
Logger improvement

### DIFF
--- a/src/lclstreamer/cmd/lclstreamer.py
+++ b/src/lclstreamer/cmd/lclstreamer.py
@@ -8,6 +8,9 @@ from typing import (
 )
 
 import typer
+from ..utils.logging import log
+import logging
+import socket
 from mpi4py import MPI
 from stream.core import Source, stream
 from stream.ops import map, take, tap  # pyright: ignore[reportUnknownVariableType]
@@ -106,6 +109,13 @@ def main(
             "--num-events", "-n", help="number of data events to read before stopping"
         ),
     ] = 0,
+    debug: Annotated[
+        bool,
+        typer.Option(
+            "--debug", "-d", help="enable showing debug info",
+            is_flag=True,
+        ),
+    ] = False,
 ) -> None:
     """
     An application that retrieves data from an event source, processes it, serializes
@@ -114,13 +124,16 @@ def main(
     further data handling are defined by the content of a configuration file
     """
 
+    if debug:
+        log.setLevel(logging.DEBUG)
+
     # 1. Read and recover configuration parameters
     mpi_size: int = MPI.COMM_WORLD.Get_size()
     mpi_rank: int = MPI.COMM_WORLD.Get_rank()
 
     parameters: Parameters = load_configuration_parameters(filename=config)
 
-    print(f"[Rank {mpi_rank}] Initializing event source....")
+    log.debug(f"[Rank {mpi_rank} {socket.gethostname()}] Initializing event source....")
 
     source: EventSourceProtocol = initialize_event_source(
         parameters=parameters,
@@ -128,21 +141,21 @@ def main(
         worker_rank=mpi_rank,
     )
 
-    print(f"[Rank {mpi_rank}] Initializing event source: Done!")
+    log.debug(f"[Rank {mpi_rank} {socket.gethostname()}] Initializing event source: Done!")
 
-    print(f"[Rank {mpi_rank}] Initializing processing pipeline....")
+    log.debug(f"[Rank {mpi_rank} {socket.gethostname()}] Initializing processing pipeline....")
     processing_pipeline: ProcessingPipelineProtocol = initialize_processing_pipeline(
         parameters
     )
-    print(f"[Rank {mpi_rank}] Initializing processing pipeline: Done!")
+    log.debug(f"[Rank {mpi_rank} {socket.gethostname()}] Initializing processing pipeline: Done!")
 
-    print(f"[Rank {mpi_rank}] Initializing data serializer....")
+    log.debug(f"[Rank {mpi_rank} {socket.gethostname()}] Initializing data serializer....")
     data_serializer: DataSerializerProtocol = initialize_data_serializer(parameters)
-    print(f"[Rank {mpi_rank}] Initializing data serializer: Done!")
+    log.debug(f"[Rank {mpi_rank} {socket.gethostname()}] Initializing data serializer: Done!")
 
-    print(f"[Rank {mpi_rank}] Initializing data handlers....")
+    log.debug(f"[Rank {mpi_rank} {socket.gethostname()}] Initializing data handlers....")
     data_handlers: list[DataHandlerProtocol] = initialize_data_handlers(parameters)
-    print(f"[Rank {mpi_rank}] Initializing data handlers: Done!")
+    log.debug(f"[Rank {mpi_rank} {socket.gethostname()}] Initializing data handlers: Done!")
 
     workflow: Any = source.get_events()
 
@@ -165,6 +178,6 @@ def main(
     workflow >>= map(_data_counter)
 
     for stat in workflow >> clock():
-        print(f"[Rank {mpi_rank}] {stat}]", flush=True)
+        log.debug(f"[Rank {mpi_rank}] {stat}]")
 
     print(f"[Rank {mpi_rank}] Hello, I'm done now.  Have a most excellent day!")

--- a/src/lclstreamer/data_handlers/streaming/binary.py
+++ b/src/lclstreamer/data_handlers/streaming/binary.py
@@ -9,7 +9,7 @@ import socket
 from ...models.parameters import (
     BinaryDataStreamingDataHandlerParameters,
 )
-from ...utils.logging import log
+from ...utils.logging import log_info, log_error
 from ...utils.protocols import DataHandlerProtocol
 
 
@@ -76,8 +76,8 @@ class BinaryStreamingPushDataHandlerZmq:
         self._socket.setsockopt(SNDHWM, 5)
 
         urls: list [str]
+        mpi_rank: int = MPI.COMM_WORLD.Get_rank()
         if data_handler_parameters.distribute:
-            mpi_rank: int = MPI.COMM_WORLD.Get_rank()
             url_length: int = len(data_handler_parameters.urls)
             world_size: int = MPI.COMM_WORLD.Get_size()
             if world_size < url_length:
@@ -86,10 +86,10 @@ class BinaryStreamingPushDataHandlerZmq:
             else:
                 urls = [data_handler_parameters.urls[mpi_rank % url_length]]
             if mpi_rank == 0:
-                log.info(f"Expecting {url_length} machines for receiving...")
-            log.info(f"Rank: {mpi_rank} on {socket.gethostname()} -> {urls}")
+                log_info(f"Expecting {url_length} machines for receiving...")
         else:
             urls = data_handler_parameters.urls
+        log_info(f"Rank: {mpi_rank} on {socket.gethostname()} -> {urls}")
         url: str
         for url in urls:
             try:
@@ -100,7 +100,7 @@ class BinaryStreamingPushDataHandlerZmq:
                     # Add delay to allow ZMQ connection to fully establish (slow joiner fix)
                     time.sleep(1.0)
             except ZMQError as err:
-                log.error(
+                log_error(
                     f"Unable to connect to the URL {url} due to the following "
                     f"error: {err}"
                 )
@@ -117,7 +117,7 @@ class BinaryStreamingPushDataHandlerZmq:
         try:
             self._socket.send(data)
         except ZMQError as e:
-            log.error("ZMQ Send failed: %s", e)
+            log_error("ZMQ Send failed: %s", e)
 
     def close(self) -> None:
         """Explicitly close the socket and context with timeout"""

--- a/src/lclstreamer/utils/logging.py
+++ b/src/lclstreamer/utils/logging.py
@@ -16,6 +16,15 @@ def log_error_and_exit(error: str) -> NoReturn:
     log.error(error)
     sys.exit(1)
 
+def log_error(error: str) -> None:
+    """
+    Logs an error message
+
+    Arguments:
+
+        error: The error message to log
+    """
+    log.error(error)
 
 def log_info(info: str) -> None:
     """
@@ -25,7 +34,17 @@ def log_info(info: str) -> None:
 
         info: The informational message to log
     """
-    log.error(info)
+    log.info(info)
+
+def log_debug(debugmsg: str) -> None:
+    """
+    Logs a debug message
+
+    Arguments:
+
+        debugmsg: The debug message to log
+    """
+    log.debug(debugmsg)
 
 
 class RichHandlerWithAggregation(RichHandler):
@@ -103,11 +122,10 @@ class RichHandlerWithAggregation(RichHandler):
 
 
 logging.basicConfig(
+    level=logging.INFO,
     format="%(message)s",
     datefmt="[%X]",
     handlers=[RichHandlerWithAggregation(rich_tracebacks=True, show_path=False)],
 )
 
-
-logging.getLogger("rich").setLevel(logging.INFO)
 log: logging.Logger = logging.getLogger("rich")


### PR DESCRIPTION
- Changed all printouts to use the logger
- Most printouts are now hidden by default
- Added showing hostname and which rank send to which host, I think it is useful info
- Added --debug arg to show all printouts

default view now is less cluttered:
<img width="450" height="170" alt="image" src="https://github.com/user-attachments/assets/bf12ba7b-09d1-4f02-b89d-00b9b8371c37" />

With --debug:
<img width="435" height="870" alt="image" src="https://github.com/user-attachments/assets/3f9e76d7-56cb-43bb-a71c-700eb0ba1eea" />
