### PR TITLE
use default factory instead of import-time

### DIFF
--- a/src/lclstreamer/models/parameters.py
+++ b/src/lclstreamer/models/parameters.py
@@ -392,7 +392,7 @@ class BinaryFileWritingDataHandlerParameters(_CustomBaseModel):
     type: Literal["BinaryFileWritingDataHandler"]
     file_prefix: str = ""
     file_suffix: str = "h5"
-    write_directory: Path = Path.cwd()
+    write_directory: Path = Field(default_factory=Path.cwd)
 
 
 DataHandlerParameters = Annotated[


### PR DESCRIPTION
this was causing issues in lclstream_api client autogeneration - since it was doing this at import time rather than at model creation time and this is a part of the openapi spec, we end up putting the home directory of whoever generated it into the client